### PR TITLE
[skip ci] fix: release workflow を GitHub UI からのリリースでも起動するよう修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+  # NOTE: GitHub UI からリリースを作成した場合は push イベントが発火しない。
+  #       release: published を追加することで UI 経由のリリースでも動作する。
+  release:
+    types: [published]
 
 permissions:
   contents: write


### PR DESCRIPTION
## 原因

`on: push: tags:` は **git コマンドで tag を push したとき** にしか発火しない。

GitHub UI（または `gh release create`）でリリースを作成すると tag はサーバー側で作成されるため、`push` イベントが発火せず workflow がスキップされる。

## 修正

`release: [published]` トリガーを追加。これにより:
- `git tag v1.0.0 && git push origin v1.0.0` → `push` イベントで起動 ✅
- GitHub UI からリリース作成 → `release: published` イベントで起動 ✅

## v0.0.5 の再実行について

このPRをマージ後、v0.0.5 のリリースを一度 Unpublish → Publish し直すか、
または `gh workflow run` で手動実行することで再トリガーできます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)