### PR TITLE
[skip ci] fix: release workflow の二重起動と PyPI manylinux wheel 対応

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-  # NOTE: GitHub UI からリリースを作成した場合は push イベントが発火しない。
-  #       release: published を追加することで UI 経由のリリースでも動作する。
+  # NOTE: GitHub UI・gh release create どちらでも発火する。
+  #       push: tags: を併用すると二重起動するため release: published のみを使う。
   release:
     types: [published]
 
@@ -243,6 +240,9 @@ jobs:
 
   # ------------------------------------------------------------------ #
   # 4c. Publish to PyPI                                                #
+  # NOTE: python -m build は plain linux_x86_64 wheel を生成するため   #
+  #       PyPI に拒否される。maturin-action は manylinux Docker 内で   #
+  #       ビルドするため manylinux_* タグの wheel が生成される。        #
   # ------------------------------------------------------------------ #
   publish-pypi:
     name: Publish to PyPI
@@ -253,29 +253,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - name: Sync version in pyproject.toml and Cargo.toml
+        run: |
+          VERSION="${{ needs.release.outputs.version }}"
+          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" packages/pypi/pyproject.toml
+          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" packages/pypi/Cargo.toml
+
+      - name: Publish to PyPI via maturin-action
+        uses: PyO3/maturin-action@v1
         with:
-          python-version: '3.10'
-
-      - name: Install build tools
-        run: pip install build twine
-
-      - name: Sync version in pyproject.toml
-        run: |
-          cd packages/pypi
-          sed -i "s/^version = \".*\"/version = \"${{ needs.release.outputs.version }}\"/" pyproject.toml
-
-      - name: Copy README for sdist
-        run: cp README.md packages/pypi/README.md
-
-      - name: Build and publish
-        run: |
-          cd packages/pypi
-          python -m build
-          twine upload dist/*
+          command: publish
+          args: --manifest-path packages/pypi/Cargo.toml --skip-existing
         env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
   # ------------------------------------------------------------------ #
   # 4d. Update Homebrew tap formula                                    #

--- a/tasks/20260306-fix-release-workflow/TODO.md
+++ b/tasks/20260306-fix-release-workflow/TODO.md
@@ -1,0 +1,42 @@
+# fix: release workflow の二重起動と PyPI manylinux 対応
+
+## 背景
+
+v0.0.5 リリース時に2つの問題が発覚。
+
+---
+
+## 問題 1: release workflow が二重起動する
+
+### 原因
+`on: push: tags:` と `on: release: published` の両方を設定しているため、
+GitHub UI からリリースを作成するとタグ作成による `push` イベントと
+リリース公開による `release: published` イベントが同時に発火する。
+
+### 対応
+- [ ] `on: push: tags:` を削除し `on: release: published` のみに統一する
+
+---
+
+## 問題 2: PyPI へのアップロードが `linux_x86_64` タグで失敗する
+
+### 原因
+`python -m build` で生成した wheel は `linux_x86_64` タグを持つが、
+PyPI は移植性のない plain linux wheel を拒否する。
+PyPI が受け付けるのは `manylinux_*` タグの wheel のみ。
+
+`packages/pypi` は maturin プロジェクトのため、`PyO3/maturin-action` を
+使って manylinux Docker コンテナ内でビルドする必要がある。
+
+### 対応
+- [ ] `publish-pypi` ジョブを `PyO3/maturin-action@v1` の `publish` コマンドに置き換える
+- [ ] `python -m build` + `twine upload` の手順を削除する
+- [ ] バージョン同期を maturin-action の引数で処理する
+
+---
+
+## 参考
+
+- [maturin-action](https://github.com/PyO3/maturin-action)
+- PyPI エラー: `Binary wheel 'mille-0.0.5-cp310-cp310-linux_x86_64.whl' has an unsupported platform tag 'linux_x86_64'`
+- 失敗した run: https://github.com/makinzm/mille/actions/runs/22747045073


### PR DESCRIPTION
## 問題

v0.0.5 リリース時に2つの問題が発覚。

### 1. workflow が二重起動する

`on: push: tags:` と `on: release: published` を両方設定していたため、
GitHub UI からリリース作成時に両イベントが同時発火していた。

**修正**: `push: tags:` を削除し `release: published` のみに統一。

### 2. PyPI アップロードが `linux_x86_64` タグで失敗する

```
ERROR: Binary wheel 'mille-0.0.5-cp310-cp310-linux_x86_64.whl' has an unsupported platform tag 'linux_x86_64'
```

`python -m build` は plain `linux_x86_64` wheel を生成するが、PyPI は `manylinux_*` タグのみ受け付ける。

**修正**: `PyO3/maturin-action@v1` の `publish` コマンドに置き換え。maturin-action は manylinux Docker コンテナ内でビルドするため `manylinux_2_28_x86_64` 等の適切なタグが付与される。

## Test plan

- [ ] 次回リリース時に workflow が1回だけ起動することを確認
- [ ] PyPI に manylinux wheel がアップロードされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)