### PR TITLE
[skip ci] fix: PyPI project description が空になる問題を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,6 +259,11 @@ jobs:
           sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" packages/pypi/pyproject.toml
           sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" packages/pypi/Cargo.toml
 
+      # NOTE: pyproject.toml の readme = "README.md" は packages/pypi/ からの相対パス。
+      #       maturin-action はリポジトリルートで動くため packages/pypi/README.md へコピーする。
+      - name: Copy README for PyPI description
+        run: cp README.md packages/pypi/README.md
+
       - name: Publish to PyPI via maturin-action
         uses: PyO3/maturin-action@v1
         with:

--- a/packages/pypi/pyproject.toml
+++ b/packages/pypi/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "maturin"
 name = "mille"
 version = "0.1.0"
 description = "Architecture Checker — static analysis for layered architecture rules"
+readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "MIT" }
 authors = [{ name = "makinzm" }]


### PR DESCRIPTION
## 原因

`packages/pypi/pyproject.toml` に `readme` フィールドが未設定だったため、
PyPI のプロジェクト説明が空になっていた。

## 修正

- `pyproject.toml` に `readme = "README.md"` を追加
- `release.yml` でリポジトリルートの `README.md` を `packages/pypi/README.md` にコピーするステップを追加
  （maturin は `packages/pypi/` からの相対パスで README を探すため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)