### PR TITLE
[skip ci] fix: release job に checkout を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,8 @@ jobs:
       version: ${{ steps.version.outputs.VERSION }}
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Extract version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

`gh release upload` 実行時に `fatal: not a git repository` エラーが発生していた問題を修正。

## 原因

`gh` CLI はリモートURL（`github.com/makinzm/mille`）の解決にローカルの git リポジトリコンテキストを使用する。
`release` ジョブには `actions/checkout@v4` が抜けていたため、git リポジトリが存在せずエラーになっていた。

## 変更内容

- `release` ジョブの冒頭に `uses: actions/checkout@v4` を追加

## 参照

https://github.com/makinzm/mille/actions/runs/22760196372/job/66014943828

🤖 Generated with [Claude Code](https://claude.com/claude-code)