### PR TITLE
[refactor] spec.md から実装依存・時限的セクションを削除

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -7,18 +7,13 @@
 ## 目次
 
 1. [概要](#1-概要)
-2. [対象言語](#2-対象言語)
-3. [チェック機能](#3-チェック機能)
-4. [opt-in / opt-out モデル](#4-opt-in--opt-out-モデル)
-5. [import解決の設計](#5-import解決の設計)
-6. [設定ファイル（mille.toml）仕様](#6-設定ファイルmilletoml仕様)
-7. [CLIインターフェース](#7-cliインターフェース)
-8. [出力フォーマット](#8-出力フォーマット)
-9. [プロジェクト内部アーキテクチャ](#9-プロジェクト内部アーキテクチャ)
-10. [ディレクトリ構成](#10-ディレクトリ構成)
-11. [配布・インストール](#11-配布インストール)
-12. [既存ツールとの比較](#12-既存ツールとの比較)
-13. [実装ロードマップ](#13-実装ロードマップ)
+2. [チェック機能](#2-チェック機能)
+3. [opt-in / opt-out モデル](#3-opt-in--opt-out-モデル)
+4. [import解決の設計](#4-import解決の設計)
+5. [設定ファイル（mille.toml）仕様](#5-設定ファイルmilletoml仕様)
+6. [CLIインターフェース](#6-cliインターフェース)
+7. [出力フォーマット](#7-出力フォーマット)
+8. [既存ツールとの比較](#8-既存ツールとの比較)
 
 ---
 
@@ -40,35 +35,20 @@ Rustで実装し、複数言語のコードベースに対応する。TOMLの設
 
 ---
 
-## 2. 対象言語
+## 2. チェック機能
 
-| 言語 | import構文 | 解析方法 |
-|---|---|---|
-| TypeScript / JavaScript | `import X from "..."` / `require("...")` | tree-sitter + tsconfig.json参照 |
-| Go | `import "pkg/path"` | tree-sitter + go.mod参照 |
-| Rust | `use crate::module` / `mod module` | tree-sitter + Cargo.toml参照 |
-| Python | `import X` / `from X import Y` | tree-sitter |
-| Java / Kotlin | `import com.example.X` | tree-sitter |
-
-言語の自動検出はファイル拡張子で行う。
-将来的には、Dart, C#, PHP, C++, CUDA などにも対応する。
-
----
-
-## 3. チェック機能
-
-### 3-1. 内部レイヤー依存チェック（コア機能）
+### 2-1. 内部レイヤー依存チェック（コア機能）
 
 レイヤーごとに `dependency_mode` を設定し、内部レイヤー間の依存違反を検出する。
 `paths` に定義されたファイルがどのレイヤーに属するかを判定し、許可されていないレイヤーへのimportをエラーとする。
-opt-in / opt-outモデルの詳細は [セクション4](#4-opt-in--opt-out-モデル) を参照。
+opt-in / opt-outモデルの詳細は [セクション3](#3-opt-in--opt-out-モデル) を参照。
 
-### 3-2. 外部ライブラリ依存チェック
+### 2-2. 外部ライブラリ依存チェック
 
 レイヤーごとに `external_mode` を設定し、外部ライブラリへの依存違反を検出する。
 内部レイヤー依存と同じopt-in / opt-outモデルで記述する。
 
-### 3-3. メソッド呼び出しチェック
+### 2-3. メソッド呼び出しチェック
 
 DI組み立て以外の目的でinfrastructureのメソッドを直接呼び出すことを禁止する。
 
@@ -102,7 +82,7 @@ repo.save(&user);   // ❌ allow_methodsに該当しない
 
 ---
 
-## 4. opt-in / opt-out モデル
+## 3. opt-in / opt-out モデル
 
 内部レイヤー間の依存（`dependency_mode`）と外部ライブラリへの依存（`external_mode`）の両方に、同一のモデルを適用する。
 
@@ -164,9 +144,9 @@ external_allow = ["clap", "serde"]
 
 ---
 
-## 5. import解決の設計
+## 4. import解決の設計
 
-### 5-1. 3段階の解決モデル
+### 4-1. 3段階の解決モデル
 
 ```
 ① テキスト抽出（全言語共通）
@@ -183,7 +163,7 @@ external_allow = ["clap", "serde"]
      どのレイヤーからどのレイヤーへの依存かを特定
 ```
 
-### 5-2. 解決モード
+### 4-2. 解決モード
 
 | モード | 説明 | 推奨言語 |
 |---|---|---|
@@ -191,7 +171,7 @@ external_allow = ["clap", "serde"]
 | `module` | モジュール名ベース | Go, Rust |
 | `hybrid` | パス・モジュール名の両方を解決 | TypeScript |
 
-### 5-3. 言語別エイリアス解決
+### 4-3. 言語別エイリアス解決
 
 ```toml
 [resolve.typescript]
@@ -211,7 +191,7 @@ src_root = "src"                       # from myapp.domain → src/myapp/domain 
 "@infra"  = "src/infrastructure"
 ```
 
-### 5-4. importの判定カテゴリ
+### 4-4. importの判定カテゴリ
 
 | カテゴリ | 説明 | 処理 |
 |---|---|---|
@@ -220,7 +200,7 @@ src_root = "src"                       # from myapp.domain → src/myapp/domain 
 | `stdlib` | 標準ライブラリ | デフォルト無視（設定で変更可） |
 | `unknown` | 解決できなかったもの | warningを出力 |
 
-### 5-5. 解決優先度
+### 4-5. 解決優先度
 
 1. `mille.toml` の手動エイリアス指定
 2. 言語設定ファイル（tsconfig.json, go.mod, Cargo.toml）から自動読み取り
@@ -228,7 +208,7 @@ src_root = "src"                       # from myapp.domain → src/myapp/domain 
 
 ---
 
-## 6. 設定ファイル（mille.toml）仕様
+## 5. 設定ファイル（mille.toml）仕様
 
 ### キー一覧
 
@@ -370,7 +350,7 @@ unknown_import           = "warning"
 
 ---
 
-## 7. CLIインターフェース
+## 6. CLIインターフェース
 
 ### コマンド構成
 
@@ -405,7 +385,7 @@ mille <command> [options]
 
 ---
 
-## 8. 出力フォーマット
+## 7. 出力フォーマット
 
 ### terminal（デフォルト）
 
@@ -485,230 +465,7 @@ Exit code: 1
 
 ---
 
-## 9. プロジェクト内部アーキテクチャ
-
-mille自身をクリーンアーキテクチャ（domain / usecase / infrastructure / presentation）で実装する。
-
-### レイヤー構成と依存方向
-
-```
-  ┌──────────────────────────────────────────┐
-  │              presentation                │  clap, 標準出力
-  │   ┌──────────────────────────────────┐   │
-  │   │          infrastructure          │   │  tree-sitter, toml, glob, fs
-  │   │   ┌──────────────────────────┐   │   │
-  │   │   │         usecase          │   │   │
-  │   │   │   ┌──────────────────┐   │   │   │
-  │   │   │   │      domain      │   │   │   │  外部依存ゼロ
-  │   │   │   └──────────────────┘   │   │   │
-  │   │   └──────────────────────────┘   │   │
-  │   └──────────────────────────────────┘   │
-  └──────────────────────────────────────────┘
-
-  依存の矢印は全て内側へ。
-  domain の Repository trait を infrastructure が impl する（依存性逆転）。
-```
-
-### 各レイヤーの責務
-
-| レイヤー | 責務 | 外部依存 |
-|---|---|---|
-| `domain` | エンティティ（Layer, Rule, Violation）・Repositoryトレイト定義・ドメインサービス | なし |
-| `usecase` | `check` / `analyze` / `report` の実行フロー定義 | domainのみ |
-| `infrastructure` | tree-sitter解析・TOMLパース・ファイル読み取り・Repositoryトレイトの実装 | tree-sitter, toml, glob 等 |
-| `presentation` | CLIコマンドパース・出力フォーマット変換・DIの組み立て | clap |
-
-### データフロー
-
-```
-mille.toml
-    │ infrastructure::TomlConfigRepository
-    ↓
-LayerConfig + RuleSet          ← domain::entity
-    │
-SourceFiles（globで収集）      ← infrastructure::FsSourceFileRepository
-    │ infrastructure::Parser（tree-sitter）
-    ↓
-RawImport一覧                  ← domain::entity::RawImport
-    │ infrastructure::Resolver
-    ↓
-ResolvedImport一覧             ← domain::entity::ResolvedImport
-    │ domain::service::ViolationDetector
-    ↓
-Violation一覧                  ← domain::entity::Violation
-    │ presentation::Formatter
-    ↓
-出力（terminal / JSON / GitHub Actions）
-```
-
----
-
-## 10. ディレクトリ構成
-
-```
-mille/
-│
-├── Cargo.toml
-├── Cargo.lock
-├── mille.toml                          # dogfooding（mille自身をチェック）
-│
-│   # =========================================================
-│   # Rustソース本体（クリーンアーキテクチャ）
-│   # =========================================================
-├── src/
-│   ├── main.rs                         # エントリーポイント（DIの組み立てのみ）
-│   │
-│   ├── domain/                         # 最内層：外部依存ゼロ
-│   │   ├── mod.rs
-│   │   ├── entity/
-│   │   │   ├── layer.rs                # Layer, LayerName, DependencyMode
-│   │   │   ├── rule.rs                 # DependencyRule, ExternalRule, CallPatternRule
-│   │   │   └── violation.rs            # Violation, Severity, ViolationKind
-│   │   ├── repository/                 # トレイト定義のみ（実装はinfrastructureに委譲）
-│   │   │   ├── source_file_repository.rs
-│   │   │   └── config_repository.rs
-│   │   └── service/
-│   │       ├── violation_detector.rs   # レイヤー判定・ルール照合
-│   │       └── import_classifier.rs    # internal / external / stdlib / unknown 分類
-│   │
-│   ├── usecase/                        # アプリケーションのフロー定義
-│   │   ├── mod.rs
-│   │   ├── check_architecture.rs       # mille check
-│   │   ├── analyze_dependencies.rs     # mille analyze
-│   │   └── report_external.rs          # mille report external
-│   │
-│   ├── infrastructure/                 # 外部ツール・ファイルシステムの実装
-│   │   ├── mod.rs
-│   │   ├── parser/                     # tree-sitterによるimport・メソッド呼び出し抽出
-│   │   │   ├── mod.rs
-│   │   │   ├── typescript.rs
-│   │   │   ├── go.rs
-│   │   │   ├── rust.rs
-│   │   │   ├── python.rs
-│   │   │   └── java.rs
-│   │   ├── resolver/                   # importパス → レイヤーへの解決
-│   │   │   ├── mod.rs
-│   │   │   ├── path_resolver.rs
-│   │   │   └── alias_resolver.rs
-│   │   └── repository/                 # domain::repositoryのトレイト実装
-│   │       ├── fs_source_file_repository.rs
-│   │       └── toml_config_repository.rs
-│   │
-│   └── presentation/                   # CLI・出力フォーマット
-│       ├── mod.rs
-│       ├── cli/
-│       │   ├── mod.rs
-│       │   └── args.rs                 # clapによるコマンド定義
-│       └── formatter/
-│           ├── terminal.rs
-│           ├── json.rs
-│           └── github_actions.rs
-│
-│   # =========================================================
-│   # 配布パッケージ（各言語のラッパー）
-│   # 実体はGitHub ReleasesのRustバイナリ。
-│   # 各ラッパーはインストール時にバイナリをDLして実行に委譲する。
-│   # =========================================================
-├── packages/
-│   ├── npm/                            # npm / npx 用
-│   │   ├── package.json
-│   │   ├── install.js                  # postinstall: OS/archに合わせてバイナリDL
-│   │   └── index.js                    # バイナリへの実行委譲
-│   │
-│   ├── pypi/                           # pip / uv add 用
-│   │   ├── pyproject.toml
-│   │   └── mille/
-│   │       ├── __init__.py
-│   │       └── _install.py             # インストール時にバイナリDL & PATH設定
-│   │
-│   └── go/                             # go install 用
-│       ├── go.mod
-│       └── main.go                     # バイナリDL & exec.Commandで委譲
-│
-│   # =========================================================
-│   # CI/CD
-│   # =========================================================
-├── .github/
-│   └── workflows/
-│       ├── ci.yml                      # テスト・lint・dogfooding
-│       └── release.yml                 # クロスコンパイル & GitHub Releases配布
-│                                       # ビルドターゲット:
-│                                       #   x86_64-unknown-linux-gnu
-│                                       #   aarch64-unknown-linux-gnu
-│                                       #   x86_64-apple-darwin
-│                                       #   aarch64-apple-darwin
-│                                       #   x86_64-pc-windows-msvc
-│
-│   # =========================================================
-│   # ドキュメント・サンプル
-│   # =========================================================
-├── docs/
-│   └── mille-spec.md
-└── examples/
-    ├── typescript-clean/               # TypeScript + クリーンアーキテクチャの設定例
-    │   └── mille.toml
-    ├── go-hexagonal/                   # Go + ヘキサゴナルの設定例
-    │   └── mille.toml
-    └── python-layered/
-        └── mille.toml
-```
-
----
-
-## 11. 配布・インストール
-
-### インストール方式の概要
-
-実体はRustでコンパイルしたシングルバイナリ。uv / go install / npm は**バイナリをダウンロードするラッパーパッケージ**として機能する（`ruff`・`biome`と同じパターン）。
-
-```
-GitHub Releases
-  ├── mille-x86_64-unknown-linux-gnu.tar.gz
-  ├── mille-aarch64-unknown-linux-gnu.tar.gz
-  ├── mille-x86_64-apple-darwin.tar.gz
-  ├── mille-aarch64-apple-darwin.tar.gz
-  └── mille-x86_64-pc-windows-msvc.zip
-         ↑ 各ラッパーがOS/archを判定してDL・配置する
-```
-
-### uv（Python）
-
-```sh
-uv add --dev mille
-uv run mille check
-```
-
-`packages/pypi/` をPyPIに公開。インストール時に `_install.py` がGitHub Releasesから対応バイナリをDLする。
-
-### go install（Go）
-
-```sh
-go install github.com/yourorg/mille/packages/go@latest
-mille check
-```
-
-`packages/go/main.go` がバイナリをDLして `exec.Command` で委譲する。
-
-### npm（Node.js）
-
-```sh
-npm install --save-dev mille
-npx mille check
-```
-
-`packages/npm/install.js`（postinstallフック）がGitHub Releasesから対応バイナリをDLする。
-
-### cargo（Rustユーザー向け）
-
-```sh
-cargo install mille
-```
-
-GitHubリポジトリからソースをビルドする。
-
----
-
-## 12. 既存ツールとの比較
+## 8. 既存ツールとの比較
 
 | ツール | 言語 | 設定方式 | 可視化 | 多言語 | 外部依存チェック |
 |---|---|---|---|---|---|
@@ -723,43 +480,8 @@ GitHubリポジトリからソースをビルドする。
 - 多言語を1つのTOMLで統一管理できる唯一のCLIツール
 - 内部依存・外部ライブラリ依存を同一のopt-in/opt-outモデルで管理
 - entrypointレイヤーのDI強制によるアーキテクチャ保護
-- uv / go install / npm / cargo すべてでインストール可能
 - Rust製シングルバイナリによる高速実行
 
 ---
 
-## 13. 実装ロードマップ
-
-### Step 1: PoC
-
-- TypeScript / GoのimportをTree-sitterで抽出
-- TOMLでレイヤー定義・`dependency_mode`を記述・チェック
-- パス文字列マッチによるレイヤー判定
-- `allow_call_patterns` によるmainチェック
-- terminal出力
-- dogfooding（mille自身にmille.tomlを設置して自己チェック）
-
-### Step 2: 精度向上
-
-- `external_mode` によるライブラリ依存チェック
-- エイリアス解決（tsconfig paths, go.modの読み取り）
-- 相対パスの絶対パス変換
-- `unknown` カテゴリのimportに対するwarning
-- Python / Rust対応追加
-
-### Step 3: 機能拡張
-
-- JSON / GitHub Actions出力対応
-- `mille analyze`コマンド（DOTグラフ出力）
-- `mille report external`コマンド
-
-### Step 4: 配布・エコシステム整備
-
-- GitHub Releasesへのクロスコンパイルバイナリ配布
-- npm / PyPI（uv）/ go installラッパーの公開
-- Java / Kotlin対応
-- `mille init`コマンド（対話形式設定生成）
-
----
-
-*最終更新: 2026-03-02*
+*最終更新: 2026-03-07*


### PR DESCRIPTION
## Summary

- 変わりやすい・実装依存のセクションを削除し、安定した仕様のみに整理
- `docs/TODO.md` や `README.md` と重複する内容を除去
- セクション番号を 1〜8 に詰め直し

### 削除したセクション

| セクション | 理由 |
|---|---|
| §2 対象言語 | 言語リストは変わる。tree-sitter ベースの設計方針は §1 に残した |
| §9 プロジェクト内部アーキテクチャ | 実装詳細（データフロー図等） |
| §10 ディレクトリ構成 | 実装とともに変わる細かい情報 |
| §11 配布・インストール | README.md に記載済み |
| §13 実装ロードマップ | `docs/TODO.md` で管理。spec に混ぜない |

### 残したセクション（安定した仕様）

1. 概要・設計方針
2. チェック機能（dependency / external / call_pattern）
3. opt-in / opt-out モデル
4. import 解決の設計
5. 設定ファイル（mille.toml）仕様
6. CLI インターフェース
7. 出力フォーマット
8. 既存ツールとの比較

🤖 Generated with [Claude Code](https://claude.com/claude-code)