### PR TITLE
refactor: DispatchingResolver::from_config() で Resolver 構築を一元化

### DIFF
--- a/packages/pypi/src/lib.rs
+++ b/packages/pypi/src/lib.rs
@@ -11,12 +11,7 @@ use mille_core::{
             fs_source_file_repository::FsSourceFileRepository,
             toml_config_repository::TomlConfigRepository,
         },
-        resolver::{
-            go::GoResolver,
-            python::PythonResolver,
-            typescript::TypeScriptResolver,
-            DispatchingResolver,
-        },
+        resolver::DispatchingResolver,
     },
     presentation::formatter::terminal::{format_layer_stats, format_summary, format_violation},
     usecase::check_architecture,
@@ -72,25 +67,8 @@ fn wire_and_check(config_path: &str) -> Result<check_architecture::CheckResult, 
         .load(config_path)
         .map_err(|e| e.to_string())?;
 
-    let go_module = app_config
-        .resolve
-        .as_ref()
-        .and_then(|r| r.go.as_ref())
-        .map(|g| g.module_name.clone())
-        .unwrap_or_default();
-    let python_packages = app_config
-        .resolve
-        .as_ref()
-        .and_then(|r| r.python.as_ref())
-        .map(|p| p.package_names.clone())
-        .unwrap_or_default();
-
     let parser = DispatchingParser::new();
-    let resolver = DispatchingResolver::new(
-        GoResolver::new(go_module),
-        PythonResolver::new(python_packages),
-        TypeScriptResolver::new(),
-    );
+    let resolver = DispatchingResolver::from_config(&app_config, config_path);
 
     check_architecture::check(config_path, &config_repo, &FsSourceFileRepository, &parser, &resolver)
 }

--- a/src/infrastructure/resolver/mod.rs
+++ b/src/infrastructure/resolver/mod.rs
@@ -3,10 +3,13 @@ pub mod python;
 pub mod rust;
 pub mod typescript;
 
+use std::collections::HashMap;
+
 use self::go::GoResolver;
 use self::python::PythonResolver;
 use self::rust::RustResolver;
 use self::typescript::TypeScriptResolver;
+use crate::domain::entity::config::MilleConfig;
 use crate::domain::entity::import::RawImport;
 use crate::domain::entity::resolved_import::ResolvedImport;
 use crate::domain::repository::resolver::Resolver;
@@ -28,6 +31,126 @@ impl DispatchingResolver {
             typescript,
         }
     }
+
+    /// Build a `DispatchingResolver` from a loaded `MilleConfig`.
+    ///
+    /// Language-specific config extraction lives here so callers only need to
+    /// call this one method — adding a new language only requires changing this
+    /// file.
+    pub fn from_config(app_config: &MilleConfig, config_path: &str) -> Self {
+        let go_module = app_config
+            .resolve
+            .as_ref()
+            .and_then(|r| r.go.as_ref())
+            .map(|g| g.module_name.clone())
+            .unwrap_or_default();
+
+        let python_packages = app_config
+            .resolve
+            .as_ref()
+            .and_then(|r| r.python.as_ref())
+            .map(|p| p.package_names.clone())
+            .unwrap_or_default();
+
+        let ts_aliases = load_ts_aliases(config_path, app_config);
+
+        DispatchingResolver {
+            rust: RustResolver,
+            go: GoResolver::new(go_module),
+            python: PythonResolver::new(python_packages),
+            typescript: TypeScriptResolver::with_aliases(ts_aliases),
+        }
+    }
+}
+
+/// Load TypeScript path aliases from the tsconfig.json referenced in mille.toml.
+///
+/// Reads `resolve.typescript.tsconfig`, parses `compilerOptions.paths`, and
+/// returns a flat map of pattern → first target.  Returns an empty map if the
+/// field is absent, the file is missing, or it has no paths entries.
+fn load_ts_aliases(config_path: &str, app_config: &MilleConfig) -> HashMap<String, String> {
+    let tsconfig_rel = match app_config
+        .resolve
+        .as_ref()
+        .and_then(|r| r.typescript.as_ref())
+        .map(|t| t.tsconfig.as_str())
+    {
+        Some(p) => p.to_string(),
+        None => return HashMap::new(),
+    };
+
+    // Resolve tsconfig path relative to the directory of mille.toml.
+    let config_dir = std::path::Path::new(config_path)
+        .parent()
+        .unwrap_or(std::path::Path::new("."));
+    let tsconfig_path = config_dir.join(&tsconfig_rel);
+
+    let content = match std::fs::read_to_string(&tsconfig_path) {
+        Ok(s) => s,
+        Err(_) => return HashMap::new(),
+    };
+
+    // NOTE: serde_json cannot parse tsconfig files that contain comments (//),
+    //       but the tsconfig.json produced by tsc --init includes comments.
+    //       We strip single-line comments before parsing as a best-effort.
+    let stripped = strip_json_line_comments(&content);
+
+    let value: serde_json::Value = match serde_json::from_str(&stripped) {
+        Ok(v) => v,
+        Err(_) => return HashMap::new(),
+    };
+
+    let paths = match value
+        .get("compilerOptions")
+        .and_then(|c| c.get("paths"))
+        .and_then(|p| p.as_object())
+    {
+        Some(p) => p,
+        None => return HashMap::new(),
+    };
+
+    let mut aliases = HashMap::new();
+    for (pattern, targets) in paths {
+        if let Some(first) = targets.as_array().and_then(|a| a.first()) {
+            if let Some(target) = first.as_str() {
+                aliases.insert(pattern.clone(), target.to_string());
+            }
+        }
+    }
+    aliases
+}
+
+/// Strip `//` single-line comments from a JSON string (best-effort for tsconfig files).
+fn strip_json_line_comments(s: &str) -> String {
+    s.lines()
+        .map(|line| {
+            // Only strip if `//` appears outside a string value.
+            // Simple heuristic: find the first `//` not inside a quoted segment.
+            let mut in_string = false;
+            let mut escaped = false;
+            let bytes = line.as_bytes();
+            let mut i = 0;
+            while i < bytes.len() {
+                let b = bytes[i];
+                if escaped {
+                    escaped = false;
+                } else if in_string {
+                    if b == b'\\' {
+                        escaped = true;
+                    } else if b == b'"' {
+                        in_string = false;
+                    }
+                } else if b == b'"' {
+                    in_string = true;
+                } else if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
+                    return &line[..i];
+                }
+                i += 1;
+            }
+            line
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn is_ts_js(file: &str) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,9 @@
-use std::collections::HashMap;
-
 use clap::Parser;
-use mille::domain::entity::config::MilleConfig;
 use mille::domain::entity::violation::Severity;
 use mille::domain::repository::config_repository::ConfigRepository;
 use mille::infrastructure::parser::DispatchingParser;
 use mille::infrastructure::repository::fs_source_file_repository::FsSourceFileRepository;
 use mille::infrastructure::repository::toml_config_repository::TomlConfigRepository;
-use mille::infrastructure::resolver::go::GoResolver;
-use mille::infrastructure::resolver::python::PythonResolver;
-use mille::infrastructure::resolver::typescript::TypeScriptResolver;
 use mille::infrastructure::resolver::DispatchingResolver;
 use mille::presentation::cli::args::Format;
 use mille::presentation::cli::args::{Cli, Command};
@@ -20,104 +14,12 @@ use mille::presentation::formatter::terminal::{
 };
 use mille::usecase::check_architecture;
 
-/// Load TypeScript path aliases from the tsconfig.json referenced in mille.toml.
-///
-/// Reads `resolve.typescript.tsconfig`, parses `compilerOptions.paths`, and
-/// returns a flat map of pattern → first target.  Returns an empty map if the
-/// field is absent, the file is missing, or it has no paths entries.
-fn load_ts_aliases(config_path: &str, app_config: &MilleConfig) -> HashMap<String, String> {
-    let tsconfig_rel = match app_config
-        .resolve
-        .as_ref()
-        .and_then(|r| r.typescript.as_ref())
-        .map(|t| t.tsconfig.as_str())
-    {
-        Some(p) => p.to_string(),
-        None => return HashMap::new(),
-    };
-
-    // Resolve tsconfig path relative to the directory of mille.toml.
-    let config_dir = std::path::Path::new(config_path)
-        .parent()
-        .unwrap_or(std::path::Path::new("."));
-    let tsconfig_path = config_dir.join(&tsconfig_rel);
-
-    let content = match std::fs::read_to_string(&tsconfig_path) {
-        Ok(s) => s,
-        Err(_) => return HashMap::new(),
-    };
-
-    // NOTE: serde_json cannot parse tsconfig files that contain comments (//),
-    //       but the tsconfig.json produced by tsc --init includes comments.
-    //       We strip single-line comments before parsing as a best-effort.
-    let stripped = strip_json_line_comments(&content);
-
-    let value: serde_json::Value = match serde_json::from_str(&stripped) {
-        Ok(v) => v,
-        Err(_) => return HashMap::new(),
-    };
-
-    let paths = match value
-        .get("compilerOptions")
-        .and_then(|c| c.get("paths"))
-        .and_then(|p| p.as_object())
-    {
-        Some(p) => p,
-        None => return HashMap::new(),
-    };
-
-    let mut aliases = HashMap::new();
-    for (pattern, targets) in paths {
-        if let Some(first) = targets.as_array().and_then(|a| a.first()) {
-            if let Some(target) = first.as_str() {
-                aliases.insert(pattern.clone(), target.to_string());
-            }
-        }
-    }
-    aliases
-}
-
-/// Strip `//` single-line comments from a JSON string (best-effort for tsconfig files).
-fn strip_json_line_comments(s: &str) -> String {
-    s.lines()
-        .map(|line| {
-            // Only strip if `//` appears outside a string value.
-            // Simple heuristic: find the first `//` not inside a quoted segment.
-            let mut in_string = false;
-            let mut escaped = false;
-            let bytes = line.as_bytes();
-            let mut i = 0;
-            while i < bytes.len() {
-                let b = bytes[i];
-                if escaped {
-                    escaped = false;
-                } else if in_string {
-                    if b == b'\\' {
-                        escaped = true;
-                    } else if b == b'"' {
-                        in_string = false;
-                    }
-                } else if b == b'"' {
-                    in_string = true;
-                } else if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
-                    return &line[..i];
-                }
-                i += 1;
-            }
-            line
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
 fn main() {
     let cli = Cli::parse();
     match cli.command {
         Command::Check { config, format } => {
-            // Pre-load config to extract the Go module name for GoResolver.
-            // NOTE: Double-load is acceptable for a CLI tool — the first load
-            // extracts the module_name to construct GoResolver, the second
-            // load happens inside check_architecture::check().
+            // Pre-load config to build the resolver, then pass path to check().
+            // NOTE: Double-load is acceptable for a CLI tool.
             let config_repo = TomlConfigRepository;
             let app_config = match config_repo.load(&config) {
                 Ok(c) => c,
@@ -126,26 +28,9 @@ fn main() {
                     std::process::exit(3);
                 }
             };
-            let go_module = app_config
-                .resolve
-                .as_ref()
-                .and_then(|r| r.go.as_ref())
-                .map(|g| g.module_name.clone())
-                .unwrap_or_default();
-            let python_packages = app_config
-                .resolve
-                .as_ref()
-                .and_then(|r| r.python.as_ref())
-                .map(|p| p.package_names.clone())
-                .unwrap_or_default();
-            let ts_aliases = load_ts_aliases(&config, &app_config);
 
             let parser = DispatchingParser::new();
-            let resolver = DispatchingResolver::new(
-                GoResolver::new(go_module),
-                PythonResolver::new(python_packages),
-                TypeScriptResolver::with_aliases(ts_aliases),
-            );
+            let resolver = DispatchingResolver::from_config(&app_config, &config);
 
             match check_architecture::check(
                 &config,


### PR DESCRIPTION
## Summary

- `DispatchingResolver::from_config(app_config, config_path)` factory メソッドを追加し、言語ごとの Resolver 構築ロジックを `resolver/mod.rs` に集約
- `main.rs` と `packages/pypi/src/lib.rs` の手動構築コードを削除し、factory メソッドの呼び出し 1 行に置換
- `load_ts_aliases()` / `strip_json_line_comments()` を `main.rs` から `resolver/mod.rs` に移動

**副次的修正**: pypi が `TypeScriptResolver::new()` を使っており TS aliases が無視されていたバグを解消（`with_aliases()` 経由に統一）

## Motivation

新しい言語を追加するとき、これまで以下の 3 ファイルを修正する必要があった：

1. `resolver/mod.rs` — フィールド追加 + dispatch arm 追加
2. `main.rs` — config 抽出 + Resolver 構築
3. `packages/pypi/src/lib.rs` — 同上

`from_config()` の導入により、変更箇所を `resolver/mod.rs` の 1 ファイルに限定できる。

## Test plan

- [x] `cargo test` — 158 unit tests + 86 E2E tests すべて通過
- [x] lefthook (clippy / fmt / test) 通過
- [x] 既存の `DispatchingResolver::new()` は変更なし（後方互換）

🤖 Generated with [Claude Code](https://claude.com/claude-code)