### PR TITLE
fix: Python entry point が sys.argv を使うよう修正

### DIFF
--- a/packages/pypi/src/lib.rs
+++ b/packages/pypi/src/lib.rs
@@ -109,12 +109,23 @@ fn check(config_path: &str) -> PyResult<CheckResult> {
 
 /// CLI entry point — called by the `mille` script installed by pip.
 ///
-/// Delegates entirely to the shared [`mille_core::runner::run_cli`] so that
-/// any new subcommand (e.g. `mille init`) is automatically available without
-/// changes to this file.
+/// Delegates to [`mille_core::runner::run_cli_from`] using Python's `sys.argv`
+/// instead of `std::env::args()`.  When the OS runs a pip entry-point script
+/// via its shebang (e.g. `python3 /path/.venv/bin/mille check`), Rust's
+/// `std::env::args()` sees `["python3", "/path/.venv/bin/mille", "check"]`
+/// and clap misinterprets the script path as a subcommand.  Python's
+/// `sys.argv` is already set to `["/path/.venv/bin/mille", "check"]` by the
+/// interpreter, so passing it to clap gives the correct parse result.
 #[pyfunction]
-fn _main() {
-    mille_core::runner::run_cli();
+fn _main(py: Python<'_>) {
+    let argv: Vec<String> = py
+        .import_bound("sys")
+        .expect("failed to import sys")
+        .getattr("argv")
+        .expect("failed to get sys.argv")
+        .extract()
+        .expect("failed to extract sys.argv as Vec<String>");
+    mille_core::runner::run_cli_from(argv);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -33,6 +33,24 @@ use crate::usecase::init::{self, DirAnalysis};
 /// Exits the process with the appropriate code on error or violation.
 pub fn run_cli() {
     let cli = Cli::parse();
+    run_cli_inner(cli);
+}
+
+/// Parse `args` and run the matching subcommand.
+///
+/// Use this from non-native entry points (e.g. the Python wrapper) where
+/// `std::env::args()` contains extra interpreter-injected arguments that
+/// clap would otherwise misinterpret as subcommands.
+pub fn run_cli_from<I, T>(args: I)
+where
+    I: IntoIterator<Item = T>,
+    T: Into<std::ffi::OsString> + Clone,
+{
+    let cli = Cli::parse_from(args);
+    run_cli_inner(cli);
+}
+
+fn run_cli_inner(cli: Cli) {
     match cli.command {
         Command::Init {
             output,


### PR DESCRIPTION
## Summary

- `uv run mille check` が `error: unrecognized subcommand '/path/.venv/bin/mille'` で落ちる問題を修正

## 根本原因

pip の entry point スクリプト（`.venv/bin/mille`）は shebang 経由で  
`python3 /path/.venv/bin/mille check` として起動される。  
このとき Rust の `std::env::args()` は:

```
["python3", "/path/.venv/bin/mille", "check"]
```

を受け取り、clap がスクリプトパスをサブコマンドと誤認して失敗する。

Python の `sys.argv` はインタープリタが正しく:

```
["/path/.venv/bin/mille", "check"]
```

に設定済みなので、`_main()` でそちらを `run_cli_from()` に渡す。

## 変更内容

- `src/runner.rs`: `run_cli_inner(cli: Cli)` を切り出し、`pub fn run_cli_from<I, T>(args)` を追加
- `packages/pypi/src/lib.rs`: `_main()` で `py.import_bound("sys").argv` を抽出して `run_cli_from` に渡す

## Test plan

- [x] ローカル `cargo test` — 194 tests all passed
- [ ] CI `dogfood-python` の `Self-check — packages/pypi itself` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)