### PR TITLE
skip ci [fix] macOS BSD sed の -i 非互換を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,8 @@ jobs:
         shell: bash
         run: |
           VERSION=${{ steps.version.outputs.VERSION }}
-          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+          sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+          rm -f Cargo.toml.bak
 
       - name: Build with cross
         if: matrix.use_cross == true
@@ -151,7 +152,8 @@ jobs:
       - name: Sync version in Cargo.toml
         run: |
           VERSION=${{ steps.version.outputs.VERSION }}
-          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+          sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+          rm -f Cargo.toml.bak
 
       - name: Build with cross
         if: matrix.use_cross == true
@@ -231,7 +233,8 @@ jobs:
       - name: Sync version in Cargo.toml
         run: |
           VERSION=${{ needs.release.outputs.version }}
-          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+          sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+          rm -f Cargo.toml.bak
 
       - name: Publish
         run: cargo publish --allow-dirty
@@ -295,8 +298,10 @@ jobs:
       - name: Sync version in pyproject.toml and Cargo.toml
         run: |
           VERSION="${{ needs.release.outputs.version }}"
-          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" packages/pypi/pyproject.toml
-          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" packages/pypi/Cargo.toml
+          sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" packages/pypi/pyproject.toml
+          rm -f packages/pypi/pyproject.toml.bak
+          sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" packages/pypi/Cargo.toml
+          rm -f packages/pypi/Cargo.toml.bak
 
       # NOTE: pyproject.toml の readme = "README.md" は packages/pypi/ からの相対パス。
       #       maturin-action はリポジトリルートで動くため packages/pypi/README.md へコピーする。
@@ -450,10 +455,14 @@ jobs:
       - name: Update versions in source files
         run: |
           VERSION=${{ steps.version.outputs.VERSION }}
-          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
-          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" packages/pypi/pyproject.toml
-          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" packages/pypi/Cargo.toml
-          sed -i "s/\"version\": \".*\"/\"version\": \"${VERSION}\"/" packages/npm/package.json
+          sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+          rm -f Cargo.toml.bak
+          sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" packages/pypi/pyproject.toml
+          rm -f packages/pypi/pyproject.toml.bak
+          sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" packages/pypi/Cargo.toml
+          rm -f packages/pypi/Cargo.toml.bak
+          sed -i.bak "s/\"version\": \".*\"/\"version\": \"${VERSION}\"/" packages/npm/package.json
+          rm -f packages/npm/package.json.bak
 
       - name: Commit and push version bump
         run: |


### PR DESCRIPTION
## Summary

- `release.yml` の全 `sed -i "..."` を `sed -i.bak "..." && rm -f *.bak` に統一
- macOS (BSD sed) では `sed -i` に拡張子引数が必須なため、`invalid command code C` エラーが発生していた
- `sed -i.bak` は GNU sed (Linux) と BSD sed (macOS) 両方で動作する

## 修正箇所

| ジョブ | ランナー | 影響 |
|---|---|---|
| `build` | `macos-latest` (darwin targets) | **直接の原因** |
| `build-deb` | `ubuntu-latest` | 一貫性のため修正 |
| `publish-crates` | `ubuntu-latest` | 一貫性のため修正 |
| `publish-pypi` | `ubuntu-latest` | 一貫性のため修正 |
| `update-version` | `ubuntu-latest` | 一貫性のため修正 |

## Test plan

- [ ] 次のリリース時に `build (x86_64-apple-darwin)` / `build (aarch64-apple-darwin)` ジョブが `Sync version in Cargo.toml` ステップで成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)