### PR TITLE
[refactor] packages/pypi: remove unused Python API, keep CLI entry point only

### DIFF
--- a/packages/pypi/Cargo.lock
+++ b/packages/pypi/Cargo.lock
@@ -69,13 +69,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
-dependencies = [
- "find-msvc-tools",
- "shlex",
-]
+checksum = "066fce287b1d4eafef758e89e09d724a24808a9196fe9756b8ca90e86d0719a2"
 
 [[package]]
 name = "cfg-if"
@@ -136,12 +132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +175,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,11 +208,14 @@ dependencies = [
  "clap",
  "glob",
  "serde",
+ "serde_json",
  "toml",
  "tree-sitter",
  "tree-sitter-go",
+ "tree-sitter-javascript",
  "tree-sitter-python",
  "tree-sitter-rust",
+ "tree-sitter-typescript",
 ]
 
 [[package]]
@@ -392,6 +391,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,12 +411,6 @@ checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "strsim"
@@ -489,6 +495,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-javascript"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8710a71bc6779e33811a8067bdda3ed08bed1733296ff915e44faf60f8c533d7"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-python"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +519,16 @@ name = "tree-sitter-rust"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "277690f420bf90741dea984f3da038ace46c4fe6047cba57a66822226cde1c93"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecb35d98a688378e56c18c9c159824fd16f730ccbea19aacf4f206e5d5438ed9"
 dependencies = [
  "cc",
  "tree-sitter",
@@ -546,3 +572,9 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/packages/pypi/mille/__init__.py
+++ b/packages/pypi/mille/__init__.py
@@ -1,3 +1,3 @@
-from .mille import check, _main, Violation, LayerStat, CheckResult
+from .mille import _main
 
-__all__ = ["check", "_main", "Violation", "LayerStat", "CheckResult"]
+__all__ = ["_main"]

--- a/packages/pypi/src/lib.rs
+++ b/packages/pypi/src/lib.rs
@@ -1,112 +1,5 @@
 use pyo3::prelude::*;
 
-use mille_core::{
-    domain::repository::config_repository::ConfigRepository,
-    infrastructure::{
-        parser::DispatchingParser,
-        repository::{
-            fs_source_file_repository::FsSourceFileRepository,
-            toml_config_repository::TomlConfigRepository,
-        },
-        resolver::DispatchingResolver,
-    },
-    usecase::check_architecture,
-};
-
-// ---------------------------------------------------------------------------
-// Exposed Python types
-// ---------------------------------------------------------------------------
-
-#[pyclass]
-#[derive(Clone)]
-pub struct Violation {
-    #[pyo3(get)]
-    pub file: String,
-    #[pyo3(get)]
-    pub line: usize,
-    #[pyo3(get)]
-    pub from_layer: String,
-    #[pyo3(get)]
-    pub to_layer: String,
-    #[pyo3(get)]
-    pub import_path: String,
-    #[pyo3(get)]
-    pub kind: String,
-}
-
-#[pyclass]
-#[derive(Clone)]
-pub struct LayerStat {
-    #[pyo3(get)]
-    pub name: String,
-    #[pyo3(get)]
-    pub file_count: usize,
-    #[pyo3(get)]
-    pub violation_count: usize,
-}
-
-#[pyclass]
-pub struct CheckResult {
-    #[pyo3(get)]
-    pub violations: Vec<Violation>,
-    #[pyo3(get)]
-    pub layer_stats: Vec<LayerStat>,
-}
-
-// ---------------------------------------------------------------------------
-// Internal helpers (not exposed to Python)
-// ---------------------------------------------------------------------------
-
-fn wire_and_check(config_path: &str) -> Result<check_architecture::CheckResult, String> {
-    let config_repo = TomlConfigRepository;
-    let app_config = config_repo
-        .load(config_path)
-        .map_err(|e| e.to_string())?;
-
-    let parser = DispatchingParser::new();
-    let resolver = DispatchingResolver::from_config(&app_config, config_path);
-
-    check_architecture::check(config_path, &config_repo, &FsSourceFileRepository, &parser, &resolver)
-}
-
-// ---------------------------------------------------------------------------
-// Public Python functions
-// ---------------------------------------------------------------------------
-
-/// Run an architecture check against `config_path` and return the result.
-///
-/// Raises `RuntimeError` if the config file cannot be loaded.
-#[pyfunction]
-#[pyo3(signature = (config_path = "mille.toml"))]
-fn check(config_path: &str) -> PyResult<CheckResult> {
-    let result = wire_and_check(config_path)
-        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e))?;
-
-    Ok(CheckResult {
-        violations: result
-            .violations
-            .into_iter()
-            .map(|v| Violation {
-                file: v.file,
-                line: v.line,
-                from_layer: v.from_layer,
-                to_layer: v.to_layer,
-                import_path: v.import_path,
-                kind: format!("{:?}", v.kind),
-            })
-            .collect(),
-        layer_stats: result
-            .layer_stats
-            .into_iter()
-            .map(|s| LayerStat {
-                name: s.name,
-                file_count: s.file_count,
-                violation_count: s.violation_count,
-            })
-            .collect(),
-    })
-}
-
 /// CLI entry point — called by the `mille` script installed by pip.
 ///
 /// Delegates to [`mille_core::runner::run_cli_from`] using Python's `sys.argv`
@@ -128,16 +21,8 @@ fn _main(py: Python<'_>) {
     mille_core::runner::run_cli_from(argv);
 }
 
-// ---------------------------------------------------------------------------
-// Module definition
-// ---------------------------------------------------------------------------
-
 #[pymodule]
 fn mille(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_class::<Violation>()?;
-    m.add_class::<LayerStat>()?;
-    m.add_class::<CheckResult>()?;
-    m.add_function(wrap_pyfunction!(check, m)?)?;
     m.add_function(wrap_pyfunction!(_main, m)?)?;
     Ok(())
 }

--- a/packages/pypi/tests/test_check.py
+++ b/packages/pypi/tests/test_check.py
@@ -1,5 +1,5 @@
 """
-mille Python extension (PyO3) の統合テスト。
+mille CLI の統合テスト (subprocess 経由)。
 
 テスト実行前に maturin develop でビルドが必要:
     cd packages/pypi && maturin develop
@@ -7,62 +7,47 @@ mille Python extension (PyO3) の統合テスト。
 
 import os
 import sys
-import pytest
+import subprocess
 
-import mille
+import pytest
 
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
 FIXTURE_RUST = os.path.join(REPO_ROOT, "tests/fixtures/rust_sample")
-FIXTURE_GO = os.path.join(REPO_ROOT, "tests/fixtures/go_sample")
+
+# Prefer the mille binary installed in the same venv as this Python interpreter.
+_VENV_MILLE = os.path.join(os.path.dirname(sys.executable), "mille")
+_MILLE = _VENV_MILLE if os.path.isfile(_VENV_MILLE) else None
 
 
-# ---------------------------------------------------------------------------
-# mille.check() — ライブラリ API
-# ---------------------------------------------------------------------------
+def run_mille(*args):
+    if _MILLE is None:
+        pytest.skip("mille not installed — run: cd packages/pypi && maturin develop")
+    return subprocess.run([_MILLE] + list(args), capture_output=True, text=True)
 
 
-def test_check_returns_check_result():
-    """mille.check() は CheckResult を返す"""
-    result = mille.check(os.path.join(REPO_ROOT, "mille.toml"))
-    assert hasattr(result, "violations")
-    assert hasattr(result, "layer_stats")
+def test_check_self_exits_zero():
+    """mille 自身の mille.toml は違反 0 件で exit 0"""
+    result = run_mille("check", "--config", os.path.join(REPO_ROOT, "mille.toml"))
+    assert result.returncode == 0
 
 
-def test_check_self_has_no_violations():
-    """mille 自身の mille.toml は違反 0 件"""
-    result = mille.check(os.path.join(REPO_ROOT, "mille.toml"))
-    assert len(result.violations) == 0
+def test_check_nonexistent_config_exits_nonzero():
+    """存在しない config ファイルは exit 非 0"""
+    result = run_mille("check", "--config", "/nonexistent/path/mille.toml")
+    assert result.returncode != 0
 
 
-def test_check_nonexistent_config_raises():
-    """存在しない config ファイルは例外を送出する"""
-    with pytest.raises(Exception):
-        mille.check("/nonexistent/path/mille.toml")
-
-
-def test_check_violation_has_expected_fields():
-    """Violation オブジェクトに期待するフィールドがある"""
+def test_check_broken_fixture_exits_nonzero():
+    """違反がある fixture は exit 非 0"""
     toml = os.path.join(FIXTURE_RUST, "mille_broken.toml")
     if not os.path.exists(toml):
         pytest.skip("broken fixture not found")
-    result = mille.check(toml)
-    assert len(result.violations) > 0
-    v = result.violations[0]
-    assert hasattr(v, "file")
-    assert hasattr(v, "line")
-    assert hasattr(v, "from_layer")
-    assert hasattr(v, "to_layer")
-    assert hasattr(v, "import_path")
-    assert hasattr(v, "kind")
+    result = run_mille("check", "--config", toml)
+    assert result.returncode != 0
 
 
-def test_check_layer_stats_populated():
-    """layer_stats に各レイヤーの情報が入っている"""
-    result = mille.check(os.path.join(REPO_ROOT, "mille.toml"))
-    assert len(result.layer_stats) > 0
-    stat = result.layer_stats[0]
-    assert hasattr(stat, "name")
-    assert hasattr(stat, "file_count")
-    assert hasattr(stat, "violation_count")
-    assert isinstance(stat.file_count, int)
+def test_help_exits_zero():
+    """mille --help は exit 0"""
+    result = run_mille("--help")
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary

- `check()` Python 関数・`Violation`・`LayerStat`・`CheckResult` pyclass を削除（CLI 経由でのみ利用されており、Python API として公開する必要がなかった）
- `wire_and_check()` ヘルパーを削除（`check` から 1 回しか呼ばれない不要な抽象化）
- `lib.rs` から不要な `use mille_core::{...}` を全削除
- `__init__.py` を `_main` のみのエクスポートに簡略化
- `tests/test_check.py` を `mille.check()` API テストから subprocess 経由 CLI テストに置き換え

## Test plan

- [x] `cargo check` 通過
- [x] lefthook (clippy / fmt / test) 通過
- [x] `pytest packages/pypi/tests/` — 3 passed, 1 skipped (broken fixture なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)