### PR TITLE
fix: mille init Go+TypeScript accuracy — module_name, full paths, TS subpath matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ The generated config includes `allow` (inferred internal dependencies) and `exte
 
 **Python submodule imports**: `external_allow = ["matplotlib"]` correctly allows both `import matplotlib` and `import matplotlib.pyplot`.
 
+**Go projects**: `mille init` reads `go.mod` and generates `[resolve.go] module_name` automatically — internal module imports are classified correctly during `mille check`. External packages appear in `external_allow` with their full import paths (e.g. `"github.com/cilium/ebpf"`, `"fmt"`, `"net/http"`).
+
+**TypeScript/JavaScript subpath imports**: `external_allow = ["vitest"]` correctly allows both `import "vitest"` and `import "vitest/config"`. Scoped packages (`@scope/name/sub`) are matched by `"@scope/name"`.
+
 ### 2. (Or) Create `mille.toml` manually
 
 Place `mille.toml` in your project root:
@@ -445,7 +449,7 @@ Use `--fail-on warning` to exit 1 even for warnings when integrating into CI gra
 
 | Key | Description |
 |---|---|
-| `module_name` | Go module name (matches `go.mod`) |
+| `module_name` | Go module name (matches `go.mod`). `mille init` generates this automatically from `go.mod`. |
 
 ### `[resolve.python]`
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -21,7 +21,8 @@
 - ✅ `mille analyze` — 依存グラフ可視化 `terminal / json / dot / svg`（PR 13）
 - ✅ `[severity]` — 違反種別ごとの重大度設定 + `--fail-on` オプション（PR 14）
 - ✅ `mille report external` — 外部ライブラリ依存をレイヤーごとにテーブル/JSON出力（PR 15）
-- ✅ `mille init` 精度改善 — 異サブプロジェクトの同名ディレクトリ分離、`.venv` スキャン除外、Python サブモジュール `external_allow` マッチング修正
+- ✅ `mille init` 精度改善 — 異サブプロジェクトの同名ディレクトリ分離、`.venv` スキャン除外、Python サブモジュール `external_allow` マッチング修正（PR #55）
+- ✅ `mille init` Go+TypeScript 対応改善 — `go.mod` から `module_name` 自動検出・生成、Go external_allow に完全パス使用、TypeScript サブパス (`vitest/config` → `vitest`) のマッチング修正（PR #56）
 
 以下は **設定ファイルにフィールドが存在しても、まだ動作していない** 項目です（README に掲載しないよう修正済み）：
 （現在なし）

--- a/src/domain/service/violation_detector.rs
+++ b/src/domain/service/violation_detector.rs
@@ -89,8 +89,16 @@ impl<'a> ViolationDetector<'a> {
                     .split('.')
                     .next()
                     .unwrap_or(&import.raw.path)
+            } else if import.raw.file.ends_with(".ts")
+                || import.raw.file.ends_with(".tsx")
+                || import.raw.file.ends_with(".js")
+                || import.raw.file.ends_with(".jsx")
+            {
+                // TypeScript/JS: "vitest/config" → "vitest", "@scope/pkg/sub" → "@scope/pkg"
+                extract_ts_package_name(&import.raw.path)
             } else {
-                // Rust/Go: "serde::Deserialize" → "serde"
+                // Rust: "serde::Deserialize" → "serde"
+                // Go: full path used as-is (no "::" separator)
                 import
                     .raw
                     .path
@@ -265,6 +273,27 @@ fn parse_severity(s: &str) -> Severity {
 /// Users write patterns as plain strings (e.g. `"github.com/foo/bar"`), no regex escaping needed.
 fn matches_external_pattern(pattern: &str, crate_name: &str) -> bool {
     pattern == crate_name
+}
+
+/// Extract the npm package name from a TypeScript/JavaScript import path.
+///
+/// - Non-scoped: `"vitest/config"` → `"vitest"`, `"react"` → `"react"`
+/// - Scoped: `"@vueuse/core/utilities"` → `"@vueuse/core"`, `"@scope/pkg"` → `"@scope/pkg"`
+fn extract_ts_package_name(path: &str) -> &str {
+    if let Some(rest) = path.strip_prefix('@') {
+        // Scoped package: @scope/name[/subpath] → @scope/name
+        // Skip '@', find first slash (end of scope), then find next slash (end of name).
+        if let Some(first_slash) = rest.find('/') {
+            let after_scope = &rest[first_slash + 1..];
+            let name_end = after_scope.find('/').unwrap_or(after_scope.len());
+            &path[..1 + first_slash + 1 + name_end]
+        } else {
+            path
+        }
+    } else {
+        // Non-scoped: first segment before '/'
+        path.split('/').next().unwrap_or(path)
+    }
 }
 
 /// Extract the type/package name brought into scope by an import path.
@@ -984,6 +1013,132 @@ mod tests {
         assert_eq!(
             violations[0].to_layer, "unknown",
             "crate_name should be 'unknown'"
+        );
+    }
+
+    #[test]
+    fn test_detect_external_ts_subpath_allowed_by_package_name() {
+        // TypeScript: "vitest/config" should match external_allow = ["vitest"]
+        // crate_name extraction uses first npm segment for TS files
+        let layers = vec![make_layer_with_external(
+            "domain",
+            &["src/domain/**"],
+            DependencyMode::OptIn,
+            &["vitest"],
+            &[],
+        )];
+        let detector = ViolationDetector::new(&layers);
+        let imports = vec![ResolvedImport {
+            raw: RawImport {
+                path: "vitest/config".to_string(),
+                line: 1,
+                file: "src/domain/test.ts".to_string(),
+                kind: ImportKind::Use,
+                named_imports: vec![],
+            },
+            category: ImportCategory::External,
+            resolved_path: None,
+        }];
+        assert!(
+            detector.detect_external(&imports).is_empty(),
+            "vitest/config should be allowed when external_allow=[\"vitest\"]"
+        );
+    }
+
+    #[test]
+    fn test_detect_external_ts_scoped_package_allowed() {
+        // TypeScript: "@vueuse/core/utilities" should match external_allow = ["@vueuse/core"]
+        let layers = vec![make_layer_with_external(
+            "domain",
+            &["src/domain/**"],
+            DependencyMode::OptIn,
+            &["@vueuse/core"],
+            &[],
+        )];
+        let detector = ViolationDetector::new(&layers);
+        let imports = vec![ResolvedImport {
+            raw: RawImport {
+                path: "@vueuse/core/utilities".to_string(),
+                line: 1,
+                file: "src/domain/component.ts".to_string(),
+                kind: ImportKind::Use,
+                named_imports: vec![],
+            },
+            category: ImportCategory::External,
+            resolved_path: None,
+        }];
+        assert!(
+            detector.detect_external(&imports).is_empty(),
+            "@vueuse/core/utilities should be allowed when external_allow=[\"@vueuse/core\"]"
+        );
+    }
+
+    #[test]
+    fn test_detect_external_go_full_path_allowed() {
+        // Go: full module path used as crate_name — exact match required
+        let layers = vec![make_layer_with_external(
+            "infra",
+            &["go/infra/**"],
+            DependencyMode::OptIn,
+            &["github.com/cilium/ebpf"],
+            &[],
+        )];
+        let detector = ViolationDetector::new(&layers);
+        let imports = vec![ResolvedImport {
+            raw: RawImport {
+                path: "github.com/cilium/ebpf".to_string(),
+                line: 1,
+                file: "go/infra/ebpf.go".to_string(),
+                kind: ImportKind::Use,
+                named_imports: vec![],
+            },
+            category: ImportCategory::External,
+            resolved_path: None,
+        }];
+        assert!(
+            detector.detect_external(&imports).is_empty(),
+            "github.com/cilium/ebpf should be allowed when exact path is in external_allow"
+        );
+    }
+
+    #[test]
+    fn test_detect_external_go_stdlib_allowed() {
+        // Go: stdlib packages ("fmt", "net/http") appear in external_allow with full path
+        let layers = vec![make_layer_with_external(
+            "domain",
+            &["go/domain/**"],
+            DependencyMode::OptIn,
+            &["fmt", "net/http"],
+            &[],
+        )];
+        let detector = ViolationDetector::new(&layers);
+        let imports = vec![
+            ResolvedImport {
+                raw: RawImport {
+                    path: "fmt".to_string(),
+                    line: 1,
+                    file: "go/domain/user.go".to_string(),
+                    kind: ImportKind::Use,
+                    named_imports: vec![],
+                },
+                category: ImportCategory::External,
+                resolved_path: None,
+            },
+            ResolvedImport {
+                raw: RawImport {
+                    path: "net/http".to_string(),
+                    line: 2,
+                    file: "go/domain/user.go".to_string(),
+                    kind: ImportKind::Use,
+                    named_imports: vec![],
+                },
+                category: ImportCategory::External,
+                resolved_path: None,
+            },
+        ];
+        assert!(
+            detector.detect_external(&imports).is_empty(),
+            "fmt and net/http should be allowed when in external_allow"
         );
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -207,9 +207,16 @@ fn run_cli_inner(cli: Cli) {
             let languages = init::detect_languages(&cwd);
             println!("Detected languages: {}", languages.join(", "));
 
+            // Detect Go module name from go.mod (if present)
+            let go_module_name = if languages.iter().any(|l| l == "go") {
+                detect_go_module_name(Path::new(&cwd))
+            } else {
+                None
+            };
+
             println!("Scanning imports...");
             let parser = DispatchingParser::new();
-            let analyses = scan_project(Path::new(&cwd), &parser, depth);
+            let analyses = scan_project(Path::new(&cwd), &parser, depth, go_module_name.as_deref());
 
             let mut layers = init::infer_layers(&analyses);
 
@@ -235,7 +242,13 @@ fn run_cli_inner(cli: Cli) {
                 layer.paths = layer.paths.iter().map(|p| format!("{}/**", p)).collect();
             }
 
-            let toml_content = init::generate_toml(&project_name, ".", &languages, &layers);
+            let toml_content = init::generate_toml(
+                &project_name,
+                ".",
+                &languages,
+                &layers,
+                go_module_name.as_deref(),
+            );
 
             match std::fs::write(output_path, &toml_content) {
                 Ok(_) => println!("\nGenerated '{}'", output),
@@ -313,6 +326,25 @@ fn run_cli_inner(cli: Cli) {
 }
 
 // ---------------------------------------------------------------------------
+// Go module detection
+// ---------------------------------------------------------------------------
+
+/// Read `go.mod` in `root` and return the module path declared on the `module` line.
+/// Returns `None` if `go.mod` is missing or no `module` line is found.
+fn detect_go_module_name(root: &Path) -> Option<String> {
+    let content = fs::read_to_string(root.join("go.mod")).ok()?;
+    for line in content.lines() {
+        if let Some(rest) = line.trim().strip_prefix("module ") {
+            let mn = rest.trim().to_string();
+            if !mn.is_empty() {
+                return Some(mn);
+            }
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
 // Project scanning — builds DirAnalysis per source directory
 // ---------------------------------------------------------------------------
 
@@ -320,6 +352,7 @@ fn scan_project(
     root: &Path,
     parser: &DispatchingParser,
     depth: Option<usize>,
+    go_module_name: Option<&str>,
 ) -> BTreeMap<String, DirAnalysis> {
     // Pass 1: collect all directories that contain at least one source file
     let mut all_source_dirs: BTreeSet<String> = BTreeSet::new();
@@ -340,7 +373,15 @@ fn scan_project(
     for dir in &layer_dirs {
         analyses.insert(dir.clone(), DirAnalysis::default());
     }
-    collect_dir_imports(root, root, parser, &layer_dirs, target_depth, &mut analyses);
+    collect_dir_imports(
+        root,
+        root,
+        parser,
+        &layer_dirs,
+        target_depth,
+        &mut analyses,
+        go_module_name,
+    );
 
     analyses
 }
@@ -395,6 +436,7 @@ fn collect_dir_imports(
     layer_dirs: &BTreeSet<String>,
     target_depth: usize,
     analyses: &mut BTreeMap<String, DirAnalysis>,
+    go_module_name: Option<&str>,
 ) {
     let Ok(entries) = fs::read_dir(dir) else {
         return;
@@ -409,9 +451,25 @@ fn collect_dir_imports(
             continue;
         }
         if path.is_dir() {
-            collect_dir_imports(root, &path, parser, layer_dirs, target_depth, analyses);
+            collect_dir_imports(
+                root,
+                &path,
+                parser,
+                layer_dirs,
+                target_depth,
+                analyses,
+                go_module_name,
+            );
         } else if is_source_file(&name) {
-            process_source_file(root, &path, parser, layer_dirs, target_depth, analyses);
+            process_source_file(
+                root,
+                &path,
+                parser,
+                layer_dirs,
+                target_depth,
+                analyses,
+                go_module_name,
+            );
         }
     }
 }
@@ -423,6 +481,7 @@ fn process_source_file(
     layer_dirs: &BTreeSet<String>,
     target_depth: usize,
     analyses: &mut BTreeMap<String, DirAnalysis>,
+    go_module_name: Option<&str>,
 ) {
     let Ok(source) = fs::read_to_string(file) else {
         return;
@@ -455,7 +514,7 @@ fn process_source_file(
         if imp.kind == ImportKind::Mod {
             continue;
         }
-        match classify_import_for_init(&imp.path, &file_rel_str) {
+        match classify_import_for_init(&imp.path, &file_rel_str, go_module_name) {
             Some(InitImport::Internal(seg)) => {
                 // Definitely internal — only add as dep if dir found; never as external
                 if let Some(dep_dir) = resolve_to_known_dir(&seg, &layer_dir, layer_dirs) {
@@ -482,6 +541,7 @@ fn process_source_file(
     }
 }
 
+#[derive(Debug)]
 enum InitImport {
     /// Definitely internal (e.g. Rust `crate::X`): don't add as external if dir not found.
     Internal(String),
@@ -491,7 +551,11 @@ enum InitImport {
     TryInternal(String),
 }
 
-fn classify_import_for_init(path: &str, file_path: &str) -> Option<InitImport> {
+fn classify_import_for_init(
+    path: &str,
+    file_path: &str,
+    go_module_name: Option<&str>,
+) -> Option<InitImport> {
     if file_path.ends_with(".rs") {
         classify_rust_import(path)
     } else if file_path.ends_with(".ts")
@@ -501,7 +565,7 @@ fn classify_import_for_init(path: &str, file_path: &str) -> Option<InitImport> {
     {
         classify_ts_import(path, file_path)
     } else if file_path.ends_with(".go") {
-        classify_go_import(path)
+        classify_go_import(path, go_module_name)
     } else if file_path.ends_with(".py") {
         classify_py_import(path)
     } else {
@@ -569,17 +633,30 @@ fn classify_ts_import(path: &str, _file_path: &str) -> Option<InitImport> {
     Some(InitImport::External(pkg))
 }
 
-fn classify_go_import(path: &str) -> Option<InitImport> {
-    // Go imports look like "github.com/org/repo/pkg" or "fmt", "os", etc.
-    // stdlib: no dots in the first segment
+fn classify_go_import(path: &str, module_name: Option<&str>) -> Option<InitImport> {
     let first = path.split('/').next()?;
-    if !first.contains('.') {
-        return None; // stdlib
+
+    // Internal: path starts with the project's module name (from go.mod)
+    if let Some(mn) = module_name.filter(|m| !m.is_empty()) {
+        if path == mn || path.starts_with(&format!("{}/", mn)) {
+            // Strip module prefix and take the first remaining segment as the layer dir
+            let rel = path.strip_prefix(&format!("{}/", mn)).unwrap_or(path);
+            let seg = rel.split('/').next()?.to_string();
+            return Some(InitImport::TryInternal(seg));
+        }
+        // We know the module name — anything else (including stdlib) is external.
+        // Record with the full import path so external_allow can match exactly.
+        let _ = first; // suppress unused-variable warning
+        return Some(InitImport::External(path.to_string()));
     }
-    // The last segment is the package name
-    // Try to match as internal first; if not found, record as external
-    let seg = path.split('/').last()?.to_string();
-    Some(InitImport::TryInternal(seg))
+
+    // module_name not known: use heuristic.
+    // No dot in first segment → likely stdlib; use full path so it appears in external_allow.
+    if !first.contains('.') {
+        return Some(InitImport::External(path.to_string()));
+    }
+    // External with dot in first segment: use full path for accurate matching.
+    Some(InitImport::External(path.to_string()))
 }
 
 fn classify_py_import(path: &str) -> Option<InitImport> {
@@ -866,5 +943,117 @@ mod tests {
         // depth=1 yields {"src"} → filtered → 0 candidates → skip
         // depth=2 yields {"src/domain", "src/usecase", "src/infrastructure"} → 3 → use
         assert_eq!(auto_detect_layer_depth(&dirs), 2);
+    }
+
+    // ------------------------------------------------------------------
+    // classify_go_import
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_classify_go_import_internal_with_module_name() {
+        // When module_name is known, matching imports → TryInternal with first sub-segment
+        let result = classify_go_import(
+            "github.com/example/myapp/domain",
+            Some("github.com/example/myapp"),
+        );
+        match result {
+            Some(InitImport::TryInternal(seg)) => {
+                assert_eq!(seg, "domain", "first sub-segment after module prefix");
+            }
+            other => panic!("expected TryInternal(\"domain\"), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_classify_go_import_stdlib_with_module_name_is_external() {
+        // When module_name is known, stdlib (no dot, no module match) → External with full path
+        let result = classify_go_import("fmt", Some("github.com/example/myapp"));
+        match result {
+            Some(InitImport::External(pkg)) => {
+                assert_eq!(pkg, "fmt");
+            }
+            other => panic!("expected External(\"fmt\"), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_classify_go_import_external_full_path_with_module_name() {
+        // External package → full path stored (not last segment)
+        let result = classify_go_import("github.com/cilium/ebpf", Some("github.com/example/myapp"));
+        match result {
+            Some(InitImport::External(pkg)) => {
+                assert_eq!(
+                    pkg, "github.com/cilium/ebpf",
+                    "full path must be stored for accurate matching"
+                );
+            }
+            other => panic!(
+                "expected External(\"github.com/cilium/ebpf\"), got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn test_classify_go_import_no_module_name_stdlib_is_external() {
+        // Without module_name, stdlib-like packages (no dot) → External with full path
+        let result = classify_go_import("fmt", None);
+        match result {
+            Some(InitImport::External(pkg)) => {
+                assert_eq!(pkg, "fmt");
+            }
+            other => panic!("expected External(\"fmt\"), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_classify_go_import_no_module_name_external_full_path() {
+        // Without module_name, external packages → External with full path
+        let result = classify_go_import("github.com/cilium/ebpf", None);
+        match result {
+            Some(InitImport::External(pkg)) => {
+                assert_eq!(pkg, "github.com/cilium/ebpf");
+            }
+            other => panic!(
+                "expected External(\"github.com/cilium/ebpf\"), got {:?}",
+                other
+            ),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // detect_go_module_name
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_detect_go_module_name_from_go_mod() {
+        let tmp = std::env::temp_dir().join(format!("mille_go_mod_test_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::fs::write(
+            tmp.join("go.mod"),
+            "module github.com/example/myapp\n\ngo 1.21\n",
+        )
+        .unwrap();
+
+        let result = detect_go_module_name(&tmp);
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert_eq!(
+            result,
+            Some("github.com/example/myapp".to_string()),
+            "module name should be extracted from go.mod"
+        );
+    }
+
+    #[test]
+    fn test_detect_go_module_name_missing_file_returns_none() {
+        let tmp = std::env::temp_dir().join(format!("mille_go_mod_missing_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        // No go.mod created
+
+        let result = detect_go_module_name(&tmp);
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert!(result.is_none(), "missing go.mod should return None");
     }
 }

--- a/src/usecase/init.rs
+++ b/src/usecase/init.rs
@@ -354,6 +354,7 @@ pub fn generate_toml(
     root: &str,
     languages: &[String],
     layers: &[LayerConfig],
+    go_module_name: Option<&str>,
 ) -> String {
     let mut out = String::new();
 
@@ -367,6 +368,16 @@ pub fn generate_toml(
         .collect::<Vec<_>>()
         .join(", ");
     out.push_str(&format!("languages = [{}]\n", langs_str));
+
+    // [resolve.go] — Go プロジェクトかつ module_name が判明している場合のみ出力
+    let is_go = languages.iter().any(|l| l == "go");
+    if is_go {
+        if let Some(mn) = go_module_name.filter(|m| !m.is_empty()) {
+            out.push('\n');
+            out.push_str("[resolve.go]\n");
+            out.push_str(&format!("module_name = \"{}\"\n", mn));
+        }
+    }
 
     // Derive Python package names from layer path base directories.
     // Used for [resolve.python] and to filter internal names from external_allow.
@@ -831,21 +842,21 @@ mod tests {
     #[test]
     fn test_generate_toml_contains_project_section() {
         let layers = vec![make_layer("domain", vec!["src/domain/**"])];
-        let toml = generate_toml("myproject", ".", &["rust".to_string()], &layers);
+        let toml = generate_toml("myproject", ".", &["rust".to_string()], &layers, None);
         assert!(toml.contains("[project]"), "must contain [project]");
     }
 
     #[test]
     fn test_generate_toml_contains_layer_sections() {
         let layers = vec![make_layer("domain", vec!["src/domain/**"])];
-        let toml = generate_toml("myproject", ".", &["rust".to_string()], &layers);
+        let toml = generate_toml("myproject", ".", &["rust".to_string()], &layers, None);
         assert!(toml.contains("[[layers]]"), "must contain [[layers]]");
     }
 
     #[test]
     fn test_generate_toml_includes_external_mode() {
         let layers = vec![make_layer("domain", vec!["src/domain/**"])];
-        let toml = generate_toml("myproject", ".", &["rust".to_string()], &layers);
+        let toml = generate_toml("myproject", ".", &["rust".to_string()], &layers, None);
         assert!(
             toml.contains("external_mode = \"opt-in\""),
             "must contain external_mode\n{}",
@@ -857,7 +868,7 @@ mod tests {
     fn test_generate_toml_with_external_allow() {
         let mut layer = make_layer("infrastructure", vec!["src/infrastructure/**"]);
         layer.external_allow = vec!["serde".to_string(), "tokio".to_string()];
-        let toml = generate_toml("myproject", ".", &["rust".to_string()], &[layer]);
+        let toml = generate_toml("myproject", ".", &["rust".to_string()], &[layer], None);
         assert!(
             toml.contains("external_allow"),
             "must contain external_allow\n{}",
@@ -872,7 +883,7 @@ mod tests {
             "domain",
             vec!["apps/crawler/src/domain/**", "apps/server/src/domain/**"],
         )];
-        let toml = generate_toml("myproject", ".", &["rust".to_string()], &layers);
+        let toml = generate_toml("myproject", ".", &["rust".to_string()], &layers, None);
         assert!(
             toml.contains("apps/crawler/src/domain/**"),
             "first path missing"
@@ -895,7 +906,7 @@ mod tests {
             make_layer("usecase", vec!["src/usecase/**"]),
             make_layer("infrastructure", vec!["src/infrastructure/**"]),
         ];
-        let toml = generate_toml("myproject", ".", &["python".to_string()], &layers);
+        let toml = generate_toml("myproject", ".", &["python".to_string()], &layers, None);
         assert!(
             toml.contains("[resolve.python]"),
             "Python プロジェクトは [resolve.python] を含むべき\n{}",
@@ -927,7 +938,7 @@ mod tests {
     fn test_generate_toml_rust_no_resolve_section() {
         // Rust プロジェクトでは [resolve.python] は出力されない
         let layers = vec![make_layer("domain", vec!["src/domain/**"])];
-        let toml = generate_toml("myproject", ".", &["rust".to_string()], &layers);
+        let toml = generate_toml("myproject", ".", &["rust".to_string()], &layers, None);
         assert!(
             !toml.contains("[resolve.python]"),
             "Rust プロジェクトに [resolve.python] は不要\n{}",
@@ -943,7 +954,7 @@ mod tests {
             make_layer("server_domain", vec!["server/src/domain/**"]),
             make_layer("crawler_usecase", vec!["crawler/src/usecase/**"]),
         ];
-        let toml = generate_toml("myproject", ".", &["python".to_string()], &layers);
+        let toml = generate_toml("myproject", ".", &["python".to_string()], &layers, None);
         // "domain" は1回だけ
         let domain_count = toml.matches("\"domain\"").count();
         assert_eq!(domain_count, 1, "domain は重複なし。toml:\n{}", toml);
@@ -960,7 +971,7 @@ mod tests {
             "dataclasses".to_string(),
         ];
         let layers = vec![domain_layer];
-        let toml = generate_toml("myproject", ".", &["python".to_string()], &layers);
+        let toml = generate_toml("myproject", ".", &["python".to_string()], &layers, None);
         // "domain" は package_names に含まれるので external_allow から除外されるべき
         // abc, dataclasses は残るべき
         // external_allow の行に "domain" が含まれないことを確認
@@ -978,6 +989,63 @@ mod tests {
         assert!(
             has_abc_in_ext_allow,
             "abc は external_allow に残るべき\n{}",
+            toml
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // generate_toml — resolve.go
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_generate_toml_go_adds_resolve_section() {
+        // Go プロジェクトで module_name が渡された場合 [resolve.go] が出力される
+        let layers = vec![make_layer("domain", vec!["go/domain/**"])];
+        let toml = generate_toml(
+            "myproject",
+            ".",
+            &["go".to_string()],
+            &layers,
+            Some("github.com/example/myproject"),
+        );
+        assert!(
+            toml.contains("[resolve.go]"),
+            "Go プロジェクトは [resolve.go] を含むべき\n{}",
+            toml
+        );
+        assert!(
+            toml.contains("module_name = \"github.com/example/myproject\""),
+            "module_name が出力されるべき\n{}",
+            toml
+        );
+    }
+
+    #[test]
+    fn test_generate_toml_go_no_resolve_without_module_name() {
+        // Go プロジェクトでも module_name が None なら [resolve.go] は出力しない
+        let layers = vec![make_layer("domain", vec!["go/domain/**"])];
+        let toml = generate_toml("myproject", ".", &["go".to_string()], &layers, None);
+        assert!(
+            !toml.contains("[resolve.go]"),
+            "module_name なしは [resolve.go] を出力しない\n{}",
+            toml
+        );
+    }
+
+    #[test]
+    fn test_generate_toml_rust_no_resolve_go_section() {
+        // Rust プロジェクトでは go_module_name を渡しても [resolve.go] は出力しない
+        let layers = vec![make_layer("domain", vec!["src/domain/**"])];
+        let toml = generate_toml(
+            "myproject",
+            ".",
+            &["rust".to_string()],
+            &layers,
+            Some("github.com/example/ignored"),
+        );
+        assert!(
+            !toml.contains("[resolve.go]"),
+            "Rust プロジェクトに [resolve.go] は不要\n{}",
             toml
         );
     }


### PR DESCRIPTION
## Summary

- `mille init` reads `go.mod` and generates `[resolve.go] module_name` automatically → internal Go imports (e.g. `makinzm/cleanarchitecture/...`) are correctly classified as Internal during `mille check`
- `classify_go_import` now stores **full import paths** in `external_pkgs` (e.g. `"github.com/cilium/ebpf"` not `"ebpf"`, stdlib `"fmt"` and `"net/http"` not skipped) → `external_allow` entries match exactly what `mille check` compares
- `detect_external` for TypeScript/JS files now extracts the **npm package name** from the import path (`"vitest/config"` → `"vitest"`, `"@scope/pkg/sub"` → `"@scope/pkg"`) → `external_allow = ["vitest"]` covers all sub-path imports

## Root Causes Fixed

| Symptom | Root Cause | Fix |
|---|---|---|
| `import makinzm/cleanarchitecture/...` → External violation | No `[resolve.go] module_name` in generated config | Read `go.mod`, emit `[resolve.go]` section |
| `external_allow = ["ebpf"]` but violation shows `github.com/cilium/ebpf` | `classify_go_import` stored last path segment | Store full import path |
| `fmt`, `time`, `context` → External violations | Stdlib skipped during init scan → missing from `external_allow` | Track stdlib as `External(path)` during scan |
| `vitest/config` not allowed by `external_allow = ["vitest"]` | `detect_external` used full path as `crate_name` for TS files | Add `extract_ts_package_name()` for TS/JS crate_name extraction |

## New Functions

- `detect_go_module_name(root: &Path) -> Option<String>` — reads `go.mod`, extracts `module` line
- `extract_ts_package_name(path: &str) -> &str` — extracts npm package root from import path
- `generate_toml()` now accepts `go_module_name: Option<&str>` and emits `[resolve.go]` when present

## Test plan

- [x] 14 new unit tests added (all 244 pass, all E2E pass)
- [x] `test_generate_toml_go_adds_resolve_section` — verifies `[resolve.go] module_name` output
- [x] `test_generate_toml_go_no_resolve_without_module_name` — no section when module unknown
- [x] `test_classify_go_import_internal_with_module_name` — internal path → `TryInternal`
- [x] `test_classify_go_import_stdlib_with_module_name_is_external` — `fmt` → `External("fmt")`
- [x] `test_classify_go_import_external_full_path_*` — full path in external_pkgs
- [x] `test_detect_go_module_name_from_go_mod` — go.mod parsing
- [x] `test_detect_external_ts_subpath_allowed_by_package_name` — `vitest/config` → `vitest`
- [x] `test_detect_external_ts_scoped_package_allowed` — `@scope/pkg/sub` → `@scope/pkg`
- [x] `test_detect_external_go_full_path_allowed` + `test_detect_external_go_stdlib_allowed` — regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)