### PR TITLE
fix: publish-pypi でルート Cargo.toml もバージョンパッチする

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,6 +298,11 @@ jobs:
       - name: Sync version in pyproject.toml and Cargo.toml
         run: |
           VERSION="${{ needs.release.outputs.version }}"
+          # NOTE: ルート Cargo.toml もパッチする。packages/pypi は path = "../.." で
+          #       ルートクレートに依存しており、clap の #[command(version)] が
+          #       ルートの CARGO_PKG_VERSION をコンパイル時に埋め込むため。
+          sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+          rm -f Cargo.toml.bak
           sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" packages/pypi/pyproject.toml
           rm -f packages/pypi/pyproject.toml.bak
           sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" packages/pypi/Cargo.toml

--- a/tasks/20260324-fix-pypi-version/TODO.md
+++ b/tasks/20260324-fix-pypi-version/TODO.md
@@ -1,0 +1,15 @@
+# fix: PyPI パッケージの `mille --version` が1つ前のバージョンを表示する
+
+## 問題
+
+`publish-pypi` ジョブがルート `Cargo.toml` のバージョンをパッチしていないため、
+`uv pip install mille` でインストールした `mille --version` が1つ前のバージョンを表示する。
+
+- `packages/pypi/Cargo.toml` → パッチ済み ✅
+- `packages/pypi/pyproject.toml` → パッチ済み ✅
+- ルート `Cargo.toml` → **未パッチ** ❌ ← clap がここから `CARGO_PKG_VERSION` を取得
+
+## タスク
+
+- [ ] `release.yml` の `publish-pypi` ジョブに ルート `Cargo.toml` の sed パッチを追加
+- [ ] timeline.md 記録

--- a/tasks/20260324-fix-pypi-version/timeline.md
+++ b/tasks/20260324-fix-pypi-version/timeline.md
@@ -1,0 +1,6 @@
+# Timeline
+
+## 2026-03-24
+
+- 調査: `publish-pypi` ジョブがルート `Cargo.toml` をバージョンパッチしていないことを特定
+- 原因: `packages/pypi/Cargo.toml` が `mille-core = { package = "mille", path = "../.." }` でルートクレートに依存。clap の `#[command(version)]` はルートの `CARGO_PKG_VERSION` を使うため、パッチ漏れで旧バージョンがコンパイル時に埋め込まれる


### PR DESCRIPTION
## Summary

- `uv pip install mille` 後の `mille --version` が1つ前のバージョンを表示する問題を修正
- `publish-pypi` ジョブの version sync ステップにルート `Cargo.toml` の sed パッチを追加
- 原因: `packages/pypi` は `path = "../.."` でルートクレートに依存しており、clap が `CARGO_PKG_VERSION`（ルート）をコンパイル時に埋め込むため

## Test plan

- [ ] 次回リリース後に `uv pip install mille && mille --version` でリリースタグと一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)