### PR TITLE
docs: README にバージョニングポリシー追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 One TOML config. Rust-powered. CI-ready. Supports multiple languages from a single config file.
 
+> **Versioning policy**
+> - `0.0.z`: Under active development. No compatibility guarantees.
+> - `0.y.z` (y ≠ 0): Compatibility maintained within the same `y`.
+> - `x.y.z` (x ≠ 0): Stable release with full operational readiness.
+
 ## What it checks
 
 **Languages:** Rust, Go, TypeScript, JavaScript, Python, Java, Kotlin, PHP, C, YAML


### PR DESCRIPTION
## Summary

- README の冒頭にバージョニングポリシーを追加
  - `0.0.z`: 開発中。互換性の保証なし
  - `0.y.z` (y ≠ 0): 同じ y 間で互換性を維持
  - `x.y.z` (x ≠ 0): 正式リリース

## Test plan

- [x] README の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)