### PR TITLE
chore: mille.toml の entrypoint/runner 分離 + SVG 更新

### DIFF
--- a/mille.svg
+++ b/mille.svg
@@ -1,29 +1,40 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="700" height="396" viewBox="0 0 700 396">
+<svg xmlns="http://www.w3.org/2000/svg" width="480" height="528" viewBox="0 0 480 528">
   <defs>
     <marker id="arrow" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#22C55E" />
     </marker>
   </defs>
   <rect width="100%" height="100%" fill="#0F172A" />
-  <path d="M 130 92 C 130 118, 350 278, 350 304" fill="none" stroke="#22C55E" stroke-width="1.5" marker-end="url(#arrow)" />
-  <text x="246" y="198" fill="#94A3B8" font-family="monospace" font-size="11" dominant-baseline="middle">30</text>
-  <path d="M 570 92 C 570 118, 350 146, 350 172" fill="none" stroke="#22C55E" stroke-width="1.5" marker-end="url(#arrow)" />
-  <text x="466" y="132" fill="#94A3B8" font-family="monospace" font-size="11" dominant-baseline="middle">2</text>
-  <path d="M 350 224 C 350 250, 350 278, 350 304" fill="none" stroke="#22C55E" stroke-width="1.5" marker-end="url(#arrow)" />
-  <text x="356" y="264" fill="#94A3B8" font-family="monospace" font-size="11" dominant-baseline="middle">15</text>
-  <rect x="260" y="304" width="180" height="52" rx="6" fill="#1E293B" stroke="#22C55E" stroke-width="1.5" />
-  <text x="350" y="324" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">domain</text>
-  <text x="350" y="340" fill="#94A3B8" font-family="monospace" font-size="10" text-anchor="middle" dominant-baseline="middle">15 files</text>
-  <rect x="40" y="40" width="180" height="52" rx="6" fill="#1E293B" stroke="#22C55E" stroke-width="1.5" />
-  <text x="130" y="60" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">infrastructure</text>
-  <text x="130" y="76" fill="#94A3B8" font-family="monospace" font-size="10" text-anchor="middle" dominant-baseline="middle">14 files</text>
+  <path d="M 130 224 C 130 250, 240 410, 240 436" fill="none" stroke="#22C55E" stroke-width="1.5" marker-end="url(#arrow)" />
+  <text x="191" y="330" fill="#94A3B8" font-family="monospace" font-size="11" dominant-baseline="middle">59</text>
+  <path d="M 350 224 C 350 250, 240 278, 240 304" fill="none" stroke="#22C55E" stroke-width="1.5" marker-end="url(#arrow)" />
+  <text x="301" y="264" fill="#94A3B8" font-family="monospace" font-size="11" dominant-baseline="middle">2</text>
+  <path d="M 350 92 C 350 118, 240 410, 240 436" fill="none" stroke="#22C55E" stroke-width="1.5" marker-end="url(#arrow)" />
+  <text x="301" y="264" fill="#94A3B8" font-family="monospace" font-size="11" dominant-baseline="middle">3</text>
+  <path d="M 350 92 C 350 118, 130 146, 130 172" fill="none" stroke="#22C55E" stroke-width="1.5" marker-end="url(#arrow)" />
+  <text x="246" y="132" fill="#94A3B8" font-family="monospace" font-size="11" dominant-baseline="middle">4</text>
+  <path d="M 350 92 C 350 118, 350 146, 350 172" fill="none" stroke="#22C55E" stroke-width="1.5" marker-end="url(#arrow)" />
+  <text x="356" y="132" fill="#94A3B8" font-family="monospace" font-size="11" dominant-baseline="middle">7</text>
+  <path d="M 350 92 C 350 118, 240 278, 240 304" fill="none" stroke="#22C55E" stroke-width="1.5" marker-end="url(#arrow)" />
+  <text x="301" y="198" fill="#94A3B8" font-family="monospace" font-size="11" dominant-baseline="middle">3</text>
+  <path d="M 240 356 C 240 382, 240 410, 240 436" fill="none" stroke="#22C55E" stroke-width="1.5" marker-end="url(#arrow)" />
+  <text x="246" y="396" fill="#94A3B8" font-family="monospace" font-size="11" dominant-baseline="middle">24</text>
+  <rect x="150" y="436" width="180" height="52" rx="6" fill="#1E293B" stroke="#22C55E" stroke-width="1.5" />
+  <text x="240" y="456" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">domain</text>
+  <text x="240" y="472" fill="#94A3B8" font-family="monospace" font-size="10" text-anchor="middle" dominant-baseline="middle">18 files</text>
+  <rect x="40" y="172" width="180" height="52" rx="6" fill="#1E293B" stroke="#22C55E" stroke-width="1.5" />
+  <text x="130" y="192" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">infrastructure</text>
+  <text x="130" y="208" fill="#94A3B8" font-family="monospace" font-size="10" text-anchor="middle" dominant-baseline="middle">23 files</text>
+  <rect x="150" y="304" width="180" height="52" rx="6" fill="#1E293B" stroke="#22C55E" stroke-width="1.5" />
+  <text x="240" y="324" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">usecase</text>
+  <text x="240" y="340" fill="#94A3B8" font-family="monospace" font-size="10" text-anchor="middle" dominant-baseline="middle">5 files</text>
   <rect x="260" y="172" width="180" height="52" rx="6" fill="#1E293B" stroke="#22C55E" stroke-width="1.5" />
-  <text x="350" y="192" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">usecase</text>
-  <text x="350" y="208" fill="#94A3B8" font-family="monospace" font-size="10" text-anchor="middle" dominant-baseline="middle">4 files</text>
-  <rect x="480" y="40" width="180" height="52" rx="6" fill="#1E293B" stroke="#22C55E" stroke-width="1.5" />
-  <text x="570" y="60" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">presentation</text>
-  <text x="570" y="76" fill="#94A3B8" font-family="monospace" font-size="10" text-anchor="middle" dominant-baseline="middle">8 files</text>
+  <text x="350" y="192" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">presentation</text>
+  <text x="350" y="208" fill="#94A3B8" font-family="monospace" font-size="10" text-anchor="middle" dominant-baseline="middle">8 files</text>
+  <rect x="40" y="40" width="180" height="52" rx="6" fill="#1E293B" stroke="#22C55E" stroke-width="1.5" />
+  <text x="130" y="60" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">entrypoint</text>
+  <text x="130" y="76" fill="#94A3B8" font-family="monospace" font-size="10" text-anchor="middle" dominant-baseline="middle">1 file</text>
   <rect x="260" y="40" width="180" height="52" rx="6" fill="#1E293B" stroke="#22C55E" stroke-width="1.5" />
-  <text x="350" y="60" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">main</text>
+  <text x="350" y="60" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">runner</text>
   <text x="350" y="76" fill="#94A3B8" font-family="monospace" font-size="10" text-anchor="middle" dominant-baseline="middle">1 file</text>
 </svg>

--- a/mille.toml
+++ b/mille.toml
@@ -41,8 +41,16 @@ external_mode = "opt-in"
 external_allow = ["clap"]
 
 [[layers]]
-name = "main"
+name = "entrypoint"
 paths = ["src/main.rs"]
+dependency_mode = "opt-in"
+allow = ["runner"]
+external_mode = "opt-in"
+external_allow = []
+
+[[layers]]
+name = "runner"
+paths = ["src/runner.rs"]
 dependency_mode = "opt-in"
 allow = ["domain", "infrastructure", "usecase", "presentation"]
 external_mode = "opt-in"
@@ -50,8 +58,12 @@ external_allow = ["clap"]
 
   [[layers.allow_call_patterns]]
   callee_layer = "usecase"
-  allow_methods = ["check", "detect_languages", "infer_layers", "generate_toml", "is_excluded_dir"]
+  allow_methods = ["check", "analyze", "report_external", "detect_languages", "infer_layers", "generate_toml", "is_excluded_dir"]
+
+  [[layers.allow_call_patterns]]
+  callee_layer = "infrastructure"
+  allow_methods = ["new", "from_resolve_config"]
 
   [[layers.allow_call_patterns]]
   callee_layer = "presentation"
-  allow_methods = ["parse"]
+  allow_methods = ["parse", "parse_from"]

--- a/tasks/20260325-fix-mille-own-toml/TODO.md
+++ b/tasks/20260325-fix-mille-own-toml/TODO.md
@@ -1,0 +1,16 @@
+# PR#79: mille 自身の mille.toml を実態に合わせる
+
+## 背景
+
+- `src/main.rs` は `mille::runner::run_cli()` を呼ぶだけの 1 行ラッパー
+- `src/runner.rs` は全レイヤーを import + clap を使う実質的なエントリポイント
+- 現状 runner.rs はどのレイヤーにも属しておらず、mille の自己チェックから漏れている
+
+## タスク
+
+- [x] mille.toml を修正: entrypoint（main.rs）と runner（runner.rs）に分離
+- [x] entrypoint は runner のみ依存許可（厳格）
+- [x] runner は全レイヤー依存 + allow_call_patterns でメソッド制限
+- [x] mille.svg + website/src/assets/mille.svg を更新
+- [x] `mille check` が通ることを確認
+- [x] 全テスト通過確認

--- a/tasks/20260325-fix-mille-own-toml/timeline.md
+++ b/tasks/20260325-fix-mille-own-toml/timeline.md
@@ -1,0 +1,16 @@
+# Timeline: PR#79
+
+## 2026-03-25
+
+### 調査
+- src/main.rs は 1 行（`mille::runner::run_cli()`）
+- src/runner.rs は全レイヤー import、clap 使用、どのレイヤーにも未所属
+- runner.rs が使うメソッド: infrastructure (DispatchingParser::new, DispatchingResolver::from_resolve_config 等), usecase (check, analyze, report_external, detect_languages, infer_layers, generate_toml, is_excluded_dir 等), presentation (Cli::parse, format_* 等)
+
+### 実装
+- main レイヤーを entrypoint + runner に分離
+  - entrypoint: src/main.rs — runner のみ依存許可（厳格）
+  - runner: src/runner.rs — 全レイヤー + clap + allow_call_patterns
+- mille check 通過確認（entrypoint 1 file, runner 1 file）
+- mille analyze --format svg で mille.svg + website/src/assets/mille.svg 更新
+- 全テスト通過

--- a/website/src/assets/mille.svg
+++ b/website/src/assets/mille.svg
@@ -1,29 +1,40 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="700" height="396" viewBox="0 0 700 396">
+<svg xmlns="http://www.w3.org/2000/svg" width="480" height="528" viewBox="0 0 480 528">
   <defs>
     <marker id="arrow" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#22C55E" />
     </marker>
   </defs>
   <rect width="100%" height="100%" fill="#0F172A" />
-  <path d="M 130 92 C 130 118, 350 278, 350 304" fill="none" stroke="#22C55E" stroke-width="1.5" marker-end="url(#arrow)" />
-  <text x="246" y="198" fill="#94A3B8" font-family="monospace" font-size="11" dominant-baseline="middle">30</text>
-  <path d="M 570 92 C 570 118, 350 146, 350 172" fill="none" stroke="#22C55E" stroke-width="1.5" marker-end="url(#arrow)" />
-  <text x="466" y="132" fill="#94A3B8" font-family="monospace" font-size="11" dominant-baseline="middle">2</text>
-  <path d="M 350 224 C 350 250, 350 278, 350 304" fill="none" stroke="#22C55E" stroke-width="1.5" marker-end="url(#arrow)" />
-  <text x="356" y="264" fill="#94A3B8" font-family="monospace" font-size="11" dominant-baseline="middle">15</text>
-  <rect x="260" y="304" width="180" height="52" rx="6" fill="#1E293B" stroke="#22C55E" stroke-width="1.5" />
-  <text x="350" y="324" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">domain</text>
-  <text x="350" y="340" fill="#94A3B8" font-family="monospace" font-size="10" text-anchor="middle" dominant-baseline="middle">15 files</text>
-  <rect x="40" y="40" width="180" height="52" rx="6" fill="#1E293B" stroke="#22C55E" stroke-width="1.5" />
-  <text x="130" y="60" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">infrastructure</text>
-  <text x="130" y="76" fill="#94A3B8" font-family="monospace" font-size="10" text-anchor="middle" dominant-baseline="middle">14 files</text>
+  <path d="M 130 224 C 130 250, 240 410, 240 436" fill="none" stroke="#22C55E" stroke-width="1.5" marker-end="url(#arrow)" />
+  <text x="191" y="330" fill="#94A3B8" font-family="monospace" font-size="11" dominant-baseline="middle">59</text>
+  <path d="M 350 224 C 350 250, 240 278, 240 304" fill="none" stroke="#22C55E" stroke-width="1.5" marker-end="url(#arrow)" />
+  <text x="301" y="264" fill="#94A3B8" font-family="monospace" font-size="11" dominant-baseline="middle">2</text>
+  <path d="M 350 92 C 350 118, 240 410, 240 436" fill="none" stroke="#22C55E" stroke-width="1.5" marker-end="url(#arrow)" />
+  <text x="301" y="264" fill="#94A3B8" font-family="monospace" font-size="11" dominant-baseline="middle">3</text>
+  <path d="M 350 92 C 350 118, 130 146, 130 172" fill="none" stroke="#22C55E" stroke-width="1.5" marker-end="url(#arrow)" />
+  <text x="246" y="132" fill="#94A3B8" font-family="monospace" font-size="11" dominant-baseline="middle">4</text>
+  <path d="M 350 92 C 350 118, 350 146, 350 172" fill="none" stroke="#22C55E" stroke-width="1.5" marker-end="url(#arrow)" />
+  <text x="356" y="132" fill="#94A3B8" font-family="monospace" font-size="11" dominant-baseline="middle">7</text>
+  <path d="M 350 92 C 350 118, 240 278, 240 304" fill="none" stroke="#22C55E" stroke-width="1.5" marker-end="url(#arrow)" />
+  <text x="301" y="198" fill="#94A3B8" font-family="monospace" font-size="11" dominant-baseline="middle">3</text>
+  <path d="M 240 356 C 240 382, 240 410, 240 436" fill="none" stroke="#22C55E" stroke-width="1.5" marker-end="url(#arrow)" />
+  <text x="246" y="396" fill="#94A3B8" font-family="monospace" font-size="11" dominant-baseline="middle">24</text>
+  <rect x="150" y="436" width="180" height="52" rx="6" fill="#1E293B" stroke="#22C55E" stroke-width="1.5" />
+  <text x="240" y="456" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">domain</text>
+  <text x="240" y="472" fill="#94A3B8" font-family="monospace" font-size="10" text-anchor="middle" dominant-baseline="middle">18 files</text>
+  <rect x="40" y="172" width="180" height="52" rx="6" fill="#1E293B" stroke="#22C55E" stroke-width="1.5" />
+  <text x="130" y="192" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">infrastructure</text>
+  <text x="130" y="208" fill="#94A3B8" font-family="monospace" font-size="10" text-anchor="middle" dominant-baseline="middle">23 files</text>
+  <rect x="150" y="304" width="180" height="52" rx="6" fill="#1E293B" stroke="#22C55E" stroke-width="1.5" />
+  <text x="240" y="324" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">usecase</text>
+  <text x="240" y="340" fill="#94A3B8" font-family="monospace" font-size="10" text-anchor="middle" dominant-baseline="middle">5 files</text>
   <rect x="260" y="172" width="180" height="52" rx="6" fill="#1E293B" stroke="#22C55E" stroke-width="1.5" />
-  <text x="350" y="192" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">usecase</text>
-  <text x="350" y="208" fill="#94A3B8" font-family="monospace" font-size="10" text-anchor="middle" dominant-baseline="middle">4 files</text>
-  <rect x="480" y="40" width="180" height="52" rx="6" fill="#1E293B" stroke="#22C55E" stroke-width="1.5" />
-  <text x="570" y="60" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">presentation</text>
-  <text x="570" y="76" fill="#94A3B8" font-family="monospace" font-size="10" text-anchor="middle" dominant-baseline="middle">8 files</text>
+  <text x="350" y="192" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">presentation</text>
+  <text x="350" y="208" fill="#94A3B8" font-family="monospace" font-size="10" text-anchor="middle" dominant-baseline="middle">8 files</text>
+  <rect x="40" y="40" width="180" height="52" rx="6" fill="#1E293B" stroke="#22C55E" stroke-width="1.5" />
+  <text x="130" y="60" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">entrypoint</text>
+  <text x="130" y="76" fill="#94A3B8" font-family="monospace" font-size="10" text-anchor="middle" dominant-baseline="middle">1 file</text>
   <rect x="260" y="40" width="180" height="52" rx="6" fill="#1E293B" stroke="#22C55E" stroke-width="1.5" />
-  <text x="350" y="60" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">main</text>
+  <text x="350" y="60" fill="#F8FAFC" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle" dominant-baseline="middle">runner</text>
   <text x="350" y="76" fill="#94A3B8" font-family="monospace" font-size="10" text-anchor="middle" dominant-baseline="middle">1 file</text>
 </svg>


### PR DESCRIPTION
## Summary

- `src/main.rs`（1行のラッパー）と `src/runner.rs`（実質エントリポイント）を別レイヤーに分離
  - **entrypoint**: `src/main.rs` — runner のみ依存許可（厳格）
  - **runner**: `src/runner.rs` — 全レイヤー依存 + `allow_call_patterns` でメソッド制限
- `runner.rs` がどのレイヤーにも属しておらず自己チェックから漏れていた問題を解消
- `mille.svg` / `website/src/assets/mille.svg` を最新の依存グラフで更新

## Test plan

- [x] `mille check` — entrypoint (1 file) + runner (1 file) として認識、0 violations
- [x] `cargo test` — 全テスト通過
- [ ] CI dogfooding で `mille check` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)