### PR TITLE
feat: Go/npm/Python 脆弱性チェック自動化 (govulncheck/npm audit/pip-audit)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+
+updates:
+  # NOTE: Go モジュール (packages/go/mille) の依存を自動更新する。
+  #       go.work で workspace 管理しているため directory は個別モジュールを指定。
+  - package-ecosystem: "gomod"
+    directory: "/packages/go/mille"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+
+  # NOTE: npm パッケージ (packages/npm) の依存を自動更新する。
+  #       現状 dependencies はないが devDependencies 追加時に備えて設定しておく。
+  - package-ecosystem: "npm"
+    directory: "/packages/npm"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+
+  # NOTE: Python パッケージ (packages/pypi) の dev deps (maturin, pytest) を自動更新する。
+  #       pip-audit でスキャンされる対象と揃える。
+  - package-ecosystem: "pip"
+    directory: "/packages/pypi"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+
+  # NOTE: GitHub Actions 自体のバージョンも追跡する。
+  #       actions/checkout 等のサプライチェーンリスクを低減する。
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/vulnerability-check.yml
+++ b/.github/workflows/vulnerability-check.yml
@@ -1,0 +1,344 @@
+name: Vulnerability Check
+
+on:
+  schedule:
+    # NOTE: 毎日 UTC 07:00 に実行。security-audit.yml (06:00) とずらして並列負荷を分散する。
+    #       Go / npm / Python の Advisory Database は日々更新されるため定期スキャンで早期検知する。
+    - cron: '0 7 * * *'
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'packages/go/mille/go.mod'
+      - 'packages/go/mille/go.sum'
+      - 'packages/npm/package.json'
+      - 'packages/npm/package-lock.json'
+      - 'packages/pypi/pyproject.toml'
+      - 'packages/pypi/uv.lock'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'packages/go/mille/go.mod'
+      - 'packages/go/mille/go.sum'
+      - 'packages/npm/package.json'
+      - 'packages/npm/package-lock.json'
+      - 'packages/pypi/pyproject.toml'
+      - 'packages/pypi/uv.lock'
+
+jobs:
+  # ------------------------------------------------------------------ #
+  # govulncheck — Go の脆弱性スキャン                                   #
+  # ------------------------------------------------------------------ #
+  go-vuln:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          # NOTE: go.work で指定したバージョンに固定する。浮動指定禁止。
+          go-version-file: 'packages/go/mille/go.mod'
+
+      # NOTE: govulncheck は Go の公式脆弱性データベースを参照する。
+      #       --json で機械読み取り可能な出力にして後続ステップで Issue 本文を生成する。
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        id: govuln
+        working-directory: packages/go/mille
+        run: |
+          if govulncheck -json ./... > govuln-result.json 2>&1; then
+            echo "vulnerable=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "vulnerable=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Show govulncheck result
+        if: always()
+        run: cat packages/go/mille/govuln-result.json || true
+
+      # NOTE: スケジュール実行で脆弱性が見つかった場合のみ Issue を作成する。
+      #       push / PR 時はワークフローの fail で十分（Issue ノイズ回避）。
+      #       既存の未クローズ Issue がある場合は重複作成しない（言語ごとに独立チェック）。
+      - name: Create GitHub Issue on vulnerability found (schedule only)
+        if: steps.govuln.outputs.vulnerable == 'true' && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const raw = fs.readFileSync('packages/go/mille/govuln-result.json', 'utf8');
+
+            // NOTE: govulncheck --json は複数行の JSON objects を出力する（JSON Lines 形式）
+            const lines = raw.trim().split('\n').filter(Boolean);
+            const findings = [];
+            for (const line of lines) {
+              try {
+                const obj = JSON.parse(line);
+                if (obj.finding) findings.push(obj.finding);
+              } catch (_) {}
+            }
+
+            const rows = findings.map(f => {
+              const osv = f.osv ?? 'N/A';
+              const symbol = f.symbol ?? 'N/A';
+              const module = f.trace?.[0]?.module ?? 'N/A';
+              const version = f.trace?.[0]?.version ?? 'N/A';
+              return `| \`${module}\` | ${version} | [${osv}](https://pkg.go.dev/vuln/${osv}) | ${symbol} |`;
+            }).join('\n');
+
+            const body = [
+              '## :rotating_light: Go 依存パッケージに脆弱性が検出されました',
+              '',
+              `検出日時: ${new Date().toISOString()}`,
+              `ワークフロー実行: [${context.runId}](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+              '',
+              '| モジュール | バージョン | OSV ID | 影響シンボル |',
+              '|---|---|---|---|',
+              rows || '(詳細取得失敗 — ワークフローログを参照)',
+              '',
+              '### 対応手順',
+              '1. `go get <モジュール>@latest` でパッチバージョンに更新',
+              '2. 修正バージョンがない場合は代替モジュールを検討',
+              '3. 対応不要と判断した場合は govulncheck の `govulncheck.yaml` に除外設定を追加してクローズ',
+            ].join('\n');
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'security',
+              state: 'open',
+            });
+            const alreadyOpen = existing.data.some(i => i.title.startsWith('[Security] Go'));
+            if (alreadyOpen) {
+              console.log('Open Go security issue already exists. Skipping creation.');
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[Security] Go 依存パッケージに脆弱性が検出されました (${new Date().toISOString().slice(0, 10)})`,
+              body,
+              labels: ['security'],
+            });
+
+      - name: Fail on vulnerability (push / PR)
+        if: steps.govuln.outputs.vulnerable == 'true' && github.event_name != 'schedule'
+        run: |
+          echo "::error::Vulnerabilities found in Go dependencies. See govuln-result.json for details."
+          exit 1
+
+  # ------------------------------------------------------------------ #
+  # npm audit — npm の脆弱性スキャン                                    #
+  # ------------------------------------------------------------------ #
+  npm-audit:
+    name: npm audit
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          # NOTE: package.json の engines.node に合わせる。
+          node-version: '20'
+
+      # NOTE: package-lock.json が存在しない場合 npm audit は実行できない。
+      #       --package-lock-only で lock ファイルだけ生成し、node_modules は作らない。
+      - name: Generate package-lock.json
+        working-directory: packages/npm
+        run: npm install --package-lock-only
+
+      - name: Run npm audit
+        id: npm_audit
+        working-directory: packages/npm
+        run: |
+          if npm audit --json > npm-audit-result.json 2>&1; then
+            echo "vulnerable=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "vulnerable=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Show npm audit result
+        if: always()
+        run: cat packages/npm/npm-audit-result.json || true
+
+      # NOTE: スケジュール実行で脆弱性が見つかった場合のみ Issue を作成する。
+      #       push / PR 時はワークフローの fail で十分（Issue ノイズ回避）。
+      #       既存の未クローズ Issue がある場合は重複作成しない（言語ごとに独立チェック）。
+      - name: Create GitHub Issue on vulnerability found (schedule only)
+        if: steps.npm_audit.outputs.vulnerable == 'true' && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const result = JSON.parse(fs.readFileSync('packages/npm/npm-audit-result.json', 'utf8'));
+            const vulns = Object.values(result.vulnerabilities ?? {});
+
+            const rows = vulns.map(v => {
+              const via = Array.isArray(v.via) ? v.via.filter(x => typeof x === 'object') : [];
+              const advisory = via[0] ?? {};
+              const cve = advisory.cve ?? 'N/A';
+              const title = advisory.title ?? v.name;
+              const url = advisory.url ?? '';
+              return `| \`${v.name}\` | ${v.range ?? 'N/A'} | ${cve} | [${title}](${url}) | ${v.severity} |`;
+            }).join('\n');
+
+            const body = [
+              '## :rotating_light: npm 依存パッケージに脆弱性が検出されました',
+              '',
+              `検出日時: ${new Date().toISOString()}`,
+              `ワークフロー実行: [${context.runId}](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+              '',
+              '| パッケージ | 影響バージョン | CVE | 概要 | 深刻度 |',
+              '|---|---|---|---|---|',
+              rows || '(詳細取得失敗 — ワークフローログを参照)',
+              '',
+              '### 対応手順',
+              '1. `npm audit fix` でパッチバージョンに自動更新',
+              '2. `npm audit fix --force` で破壊的変更を伴うアップデートを適用（要動作確認）',
+              '3. 対応不要と判断した場合はコメントで根拠を残してクローズ',
+            ].join('\n');
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'security',
+              state: 'open',
+            });
+            const alreadyOpen = existing.data.some(i => i.title.startsWith('[Security] npm'));
+            if (alreadyOpen) {
+              console.log('Open npm security issue already exists. Skipping creation.');
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[Security] npm 依存パッケージに脆弱性が検出されました (${new Date().toISOString().slice(0, 10)})`,
+              body,
+              labels: ['security'],
+            });
+
+      - name: Fail on vulnerability (push / PR)
+        if: steps.npm_audit.outputs.vulnerable == 'true' && github.event_name != 'schedule'
+        run: |
+          echo "::error::Vulnerabilities found in npm dependencies. See npm-audit-result.json for details."
+          exit 1
+
+  # ------------------------------------------------------------------ #
+  # pip-audit — Python の脆弱性スキャン                                 #
+  # ------------------------------------------------------------------ #
+  python-audit:
+    name: pip-audit
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          # NOTE: pyproject.toml の requires-python に合わせる。
+          python-version: '3.12'
+
+      # NOTE: pip-audit は PyPA Advisory Database を参照する。
+      #       uv で管理されている dev deps (maturin, pytest) のみを対象にスキャンする。
+      #       --requirement で uv.lock から生成した requirements.txt を渡す方式にする。
+      - name: Install uv
+        run: pip install uv
+
+      - name: Export requirements from uv.lock
+        working-directory: packages/pypi
+        run: |
+          # NOTE: uv export で dev deps を含む全依存を requirements.txt に出力する。
+          #       --no-hashes で pip-audit との互換性を保つ。
+          uv export --dev --no-hashes -o requirements-dev.txt
+
+      - name: Install pip-audit
+        run: pip install pip-audit
+
+      - name: Run pip-audit
+        id: pip_audit
+        working-directory: packages/pypi
+        run: |
+          if pip-audit -r requirements-dev.txt --format json -o pip-audit-result.json 2>&1; then
+            echo "vulnerable=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "vulnerable=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Show pip-audit result
+        if: always()
+        run: cat packages/pypi/pip-audit-result.json || true
+
+      # NOTE: スケジュール実行で脆弱性が見つかった場合のみ Issue を作成する。
+      #       push / PR 時はワークフローの fail で十分（Issue ノイズ回避）。
+      #       既存の未クローズ Issue がある場合は重複作成しない（言語ごとに独立チェック）。
+      - name: Create GitHub Issue on vulnerability found (schedule only)
+        if: steps.pip_audit.outputs.vulnerable == 'true' && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const result = JSON.parse(fs.readFileSync('packages/pypi/pip-audit-result.json', 'utf8'));
+            const vulns = result.dependencies?.flatMap(dep =>
+              (dep.vulns ?? []).map(v => ({ pkg: dep.name, version: dep.version, ...v }))
+            ) ?? [];
+
+            const rows = vulns.map(v => {
+              const aliases = (v.aliases ?? []).join(', ') || 'N/A';
+              return `| \`${v.pkg}\` | ${v.version} | ${v.id} | ${aliases} | ${v.description ?? 'N/A'} |`;
+            }).join('\n');
+
+            const body = [
+              '## :rotating_light: Python 依存パッケージに脆弱性が検出されました',
+              '',
+              `検出日時: ${new Date().toISOString()}`,
+              `ワークフロー実行: [${context.runId}](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+              '',
+              '| パッケージ | バージョン | ID | CVE | 概要 |',
+              '|---|---|---|---|---|',
+              rows || '(詳細取得失敗 — ワークフローログを参照)',
+              '',
+              '### 対応手順',
+              '1. `uv lock --upgrade-package <パッケージ名>` でパッチバージョンに更新',
+              '2. 修正バージョンがない場合は代替パッケージを検討',
+              '3. 対応不要と判断した場合はコメントで根拠を残してクローズ',
+            ].join('\n');
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'security',
+              state: 'open',
+            });
+            const alreadyOpen = existing.data.some(i => i.title.startsWith('[Security] Python'));
+            if (alreadyOpen) {
+              console.log('Open Python security issue already exists. Skipping creation.');
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[Security] Python 依存パッケージに脆弱性が検出されました (${new Date().toISOString().slice(0, 10)})`,
+              body,
+              labels: ['security'],
+            });
+
+      - name: Fail on vulnerability (push / PR)
+        if: steps.pip_audit.outputs.vulnerable == 'true' && github.event_name != 'schedule'
+        run: |
+          echo "::error::Vulnerabilities found in Python dependencies. See pip-audit-result.json for details."
+          exit 1

--- a/.github/workflows/vulnerability-check.yml
+++ b/.github/workflows/vulnerability-check.yml
@@ -45,8 +45,9 @@ jobs:
 
       # NOTE: govulncheck は Go の公式脆弱性データベースを参照する。
       #       --json で機械読み取り可能な出力にして後続ステップで Issue 本文を生成する。
+      # NOTE: v1.1.4 で固定。浮動指定 (@latest) を避けて再現性を確保する。
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
       - name: Run govulncheck
         id: govuln
@@ -263,7 +264,9 @@ jobs:
         run: |
           # NOTE: uv export で dev deps を含む全依存を requirements.txt に出力する。
           #       --no-hashes で pip-audit との互換性を保つ。
-          uv export --dev --no-hashes -o requirements-dev.txt
+          #       --no-emit-project でパッケージ自体 (-e .) を除外する（pip-audit が
+          #       ローカルビルドを要求しないよう回避する）。
+          uv export --dev --no-hashes --no-emit-project -o requirements-dev.txt
 
       - name: Install pip-audit
         run: pip install pip-audit

--- a/packages/pypi/uv.lock
+++ b/packages/pypi/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 
+[options]
+exclude-newer = "2026-03-29T22:21:16.473532Z"
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "colorama"
 version = "0.4.6"
@@ -77,7 +81,7 @@ wheels = [
 
 [[package]]
 name = "mille"
-version = "0.1.0"
+version = "0.0.14"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/tasks/20260406-vuln-check/TODO.md
+++ b/tasks/20260406-vuln-check/TODO.md
@@ -1,0 +1,36 @@
+# TODO: Go / npm / Python 脆弱性チェック自動化
+
+## 目的
+
+Go (govulncheck)、npm (npm audit)、Python (pip-audit) の依存脆弱性を定期スキャンし、
+脆弱性発見時に GitHub Issue を自動作成する。
+cargo の脆弱性チェックは既存の `security-audit.yml` でカバー済みのため対象外。
+
+## 対象ファイル
+
+- `.github/dependabot.yml` — 新規作成（Go / npm / pip のバージョン自動更新PR）
+- `.github/workflows/vulnerability-check.yml` — 新規作成（Go / npm / Python の脆弱性スキャン）
+
+## タスク一覧
+
+- [x] ブランチ作成 (`feat/pr92-vuln-check-go-npm-python`)
+- [x] TODO.md / timeline.md 作成
+- [ ] `.github/dependabot.yml` 実装
+- [ ] `.github/workflows/vulnerability-check.yml` 実装
+- [ ] DAレビュー
+- [ ] docs/TODO.md / README.md 更新要否確認
+- [ ] PR 作成
+
+## 仕様決定事項
+
+1. `npm install --package-lock-only` で lock ファイルを生成してから `npm audit` 実行
+2. Python は dev deps (maturin, pytest) のみ対象 — `packages/pypi/` ディレクトリを対象
+3. Issue 重複チェックは言語ごとに独立:
+   - `[Security] Go ...`
+   - `[Security] npm ...`
+   - `[Security] Python ...`
+
+## Issue 自動作成条件
+
+- スケジュール実行 (schedule) で脆弱性発見 → Issue 作成
+- push / PR 時に脆弱性発見 → ワークフロー fail のみ（Issue ノイズ回避）

--- a/tasks/20260406-vuln-check/da-review.md
+++ b/tasks/20260406-vuln-check/da-review.md
@@ -1,0 +1,44 @@
+# DA Review: Go / npm / Python 脆弱性チェック
+
+## レビュー日時
+2026-04-06
+
+## 対象コミット
+- e9cfc9b: 初回実装 (.github/dependabot.yml + vulnerability-check.yml)
+
+## チェック観点
+
+### バグ・論理ミス
+- [x] govulncheck の working-directory とファイルパス参照の整合性 — 問題なし
+- [x] npm audit --json の exit code 判定 — 問題なし（リダイレクトは exit code に影響しない）
+- [x] pip-audit の exit code 判定 — 問題なし
+- [ISSUE] `govulncheck@latest` — CLAUDE.md のバージョン固定ルール違反 → `@v1.1.4` に修正
+- [ISSUE] `uv export` に `-e .` が含まれる — pip-audit がローカルビルドを要求する可能性 → `--no-emit-project` を追加して修正
+
+### セキュリティ
+- [x] `issues: write` / `contents: read` — 最小権限の原則に従っている
+- [x] `actions/github-script@v7` タグ固定 — プロジェクトパターンと一致
+- [x] サプライチェーンリスク — dependabot で github-actions も追跡対象にしている
+
+### テストの十分性
+- CI 設定のみのため、ユニットテストは不適用
+- スケジュール・push・PR の3トリガーをカバー
+- vulnerable / not vulnerable の両パスを実装
+
+### コードの可読性・保守性
+- [x] インラインコメントは `NOTE:` 形式
+- [x] Issue 重複チェックが言語ごとに独立（`[Security] Go`, `[Security] npm`, `[Security] Python`）
+- [x] 3 job 構成で各言語が独立してデプロイ/確認可能
+
+### CLAUDE.md プロセス原則
+- [x] `[skip ci]` / `[ci skip]` なし
+- [x] コミットメッセージ形式 `[fix]` 準拠
+
+## 修正実施内容
+
+1. `govulncheck@latest` → `@v1.1.4` に固定（commit: ffb4341）
+2. `uv export --no-emit-project` 追加（commit: ffb4341）
+
+## 判定
+
+**LGTM** — 指摘事項を全て修正済み。PR 作成可能。

--- a/tasks/20260406-vuln-check/timeline.md
+++ b/tasks/20260406-vuln-check/timeline.md
@@ -1,0 +1,24 @@
+# Timeline: Go / npm / Python 脆弱性チェック自動化
+
+## 2026-04-06
+
+### 計画フェーズ
+- ユーザーへ確認事項を提示
+- 回答受領:
+  1. npm: `npm install --package-lock-only` → `npm audit` の方針
+  2. Python: dev deps のみ (maturin, pytest) — `packages/pypi/` を対象
+  3. Issue 重複チェックは言語ごとに独立
+
+### 調査
+- `security-audit.yml` のパターン確認（Issue作成・スケジュール・push/PRトリガー）
+- Go: `packages/go/mille/go.mod` に `wazero` と `golang.org/x/sys` が依存
+- npm: `packages/npm/package.json` — dependencies なし、`mille.wasm` バイナリ配布形式
+- Python: `packages/pypi/pyproject.toml` — dev deps: `maturin>=1.12.6`, `pytest>=8`
+- `packages/pypi/uv.lock` が存在 (uv で管理)
+
+### ブランチ作成
+- `feat/pr92-vuln-check-go-npm-python` を作成
+
+### 次のステップ
+- `dependabot.yml` 実装
+- `vulnerability-check.yml` 実装


### PR DESCRIPTION
## 概要

Go / npm / Python の依存パッケージの脆弱性を自動スキャンし、発見時に GitHub Issue を自動作成するワークフローを追加する。
cargo の脆弱性チェックは既存の `security-audit.yml` でカバー済みのため対象外。

## 変更内容

### `.github/dependabot.yml` (新規)
- Go (`packages/go/mille`)、npm (`packages/npm`)、pip (`packages/pypi`)、GitHub Actions の自動バージョン更新PRを設定
- 毎週スキャン、`dependencies` ラベルを付与

### `.github/workflows/vulnerability-check.yml` (新規)
3 つの独立した job を実装:

- **`go-vuln`**: `govulncheck@v1.1.4` で Go 依存をスキャン
- **`npm-audit`**: `npm install --package-lock-only` で lock ファイル生成後 `npm audit` 実行
- **`python-audit`**: `uv export --dev --no-hashes --no-emit-project` で requirements.txt 生成後 `pip-audit` 実行

共通動作:
- スケジュール実行 (毎日 UTC 07:00) で脆弱性発見 → GitHub Issue 自動作成
- push / PR 時に脆弱性発見 → ワークフロー fail のみ（Issue ノイズ回避）
- Issue 重複チェックは言語ごとに独立 (`[Security] Go`, `[Security] npm`, `[Security] Python`)

## トリガー条件

| イベント | 条件 |
|---|---|
| schedule | 毎日 UTC 07:00 |
| push (main) | `packages/go/mille/go.{mod,sum}`, `packages/npm/package{,-lock}.json`, `packages/pypi/{pyproject.toml,uv.lock}` |
| pull_request (main) | 同上 |

## 設計上の注意事項

- `govulncheck` は `@latest` ではなく `@v1.1.4` でバージョン固定（CLAUDE.md のルール準拠）
- `uv export` に `--no-emit-project` を追加して `-e .`（ローカルパッケージ自体）を除外
- `security-audit.yml` (UTC 06:00) と時刻をずらして並列負荷を分散 (UTC 07:00)

## チェックリスト
- [x] lefthook 通過（CI 設定のみのためローカルでの確認済み）
- [x] DAレビュー完了 (LGTM — tasks/20260406-vuln-check/da-review.md)
- [x] docs/TODO.md 更新不要（ユーザー向け機能追加なし）
- [x] README.md 更新不要（CLI オプション・設定変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)