### PR TITLE
[fix] uv.lock バージョン不整合修正 (0.1.0 → 0.0.14)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -469,6 +469,16 @@ jobs:
           sed -i.bak "s/\"version\": \".*\"/\"version\": \"${VERSION}\"/" packages/npm/package.json
           rm -f packages/npm/package.json.bak
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Regenerate uv.lock
+        working-directory: packages/pypi
+        # NOTE: pyproject.toml のバージョンを更新した後 uv.lock を再生成しないと
+        #       uv.lock 内の mille パッケージバージョンが古いまま残り不整合が生じる。
+        #       uv lock --locked は既存 lock との整合チェックのみなので --upgrade-package で再生成する。
+        run: uv lock
+
       - name: Commit and push version bump
         run: |
           VERSION=${{ steps.version.outputs.VERSION }}
@@ -477,7 +487,7 @@ jobs:
           if git diff --exit-code; then
             echo "Version already up to date. No commit needed."
           else
-            git add Cargo.toml packages/pypi/pyproject.toml packages/pypi/Cargo.toml packages/npm/package.json
+            git add Cargo.toml packages/pypi/pyproject.toml packages/pypi/Cargo.toml packages/npm/package.json packages/pypi/uv.lock
             git commit -m "[fix] v${VERSION} リリース後のバージョン更新 [skip ci]"
             git push origin main
           fi

--- a/packages/pypi/uv.lock
+++ b/packages/pypi/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 
+[options]
+exclude-newer = "2026-03-29T22:21:16.473532Z"
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "colorama"
 version = "0.4.6"
@@ -77,7 +81,7 @@ wheels = [
 
 [[package]]
 name = "mille"
-version = "0.1.0"
+version = "0.0.14"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- `packages/pypi/uv.lock` のパッケージバージョンが `0.1.0` になっていたのを `0.0.14` に修正
- `release.yml` の `update-version` ジョブに `uv lock` 再生成ステップを追加し、今後のリリースで同じ不整合が起きないよう根本修正

## Root Cause

`release.yml` の `update-version` ジョブで `pyproject.toml` のバージョンを `sed` で書き換えているが、`uv.lock` の再生成をしていなかった。そのため `uv.lock` 内の `mille` パッケージバージョンが古いまま残り不整合が生じていた。

## Fix

1. **一時修正**: `uv.lock` を現在の `pyproject.toml` バージョン (`0.0.14`) に合わせて修正
2. **根本修正**: `release.yml` の `update-version` ジョブに `uv lock` の再生成ステップを追加し、`uv.lock` も commit に含めるよう修正

## Test plan

- [ ] 次回リリース後、`packages/pypi/uv.lock` の `mille` バージョンがリリースバージョンと一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)